### PR TITLE
Evolution du plugin pour carte citoyen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
             <groupId>fr.paris.lutece</groupId>
             <artifactId>lutece-core</artifactId>
             <version>[5.0.0,)</version>
-            <type>lutece-core</type>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
             <groupId>fr.paris.lutece</groupId>
             <artifactId>lutece-core</artifactId>
             <version>[5.0.0,)</version>
+            <type>lutece-core</type>
         </dependency>
     </dependencies>
 

--- a/src/java/fr/paris/lutece/plugins/uploadimage/business/Options.java
+++ b/src/java/fr/paris/lutece/plugins/uploadimage/business/Options.java
@@ -30,71 +30,74 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * License 1.0
- */ 
+ */
 package fr.paris.lutece.plugins.uploadimage.business;
 
 import javax.validation.constraints.*;
-import org.hibernate.validator.constraints.*;
 
+import org.hibernate.validator.constraints.*;
 
 /**
  * This is the business class for the object Options
- */ 
+ */
 public class Options
 {
     // Variables declarations 
     private int _nId;
-    
+
     private boolean _bStrict;
-    
+
     private boolean _bResponsive;
-    
+
     private boolean _bCheckImageOrigin;
-    
+
     private boolean _bModal;
-    
+
     private boolean _bGuides;
-    
+
     private boolean _bHighlight;
-    
+
     private boolean _bBackground;
-    
+
     private boolean _bAutoCrop;
-    
+
     private boolean _bDragCrop;
-    
+
     private boolean _bMovable;
-    
+
     private boolean _bRotatable;
-    
+
     private boolean _bZoomable;
-    
+
     private boolean _bTouchDragZoom;
-    
+
     private boolean _bMouseWheelZoom;
-    
+
     private boolean _bCropBoxMovable;
-    
+
     private boolean _bCropBoxResizable;
-    
+
     private boolean _bDoubleClickToggle;
-    
+
     private int _nWidth;
-    
+
     private int _nHeight;
-    
+
     private int _nX;
-    
+
     private int _nY;
-    
-    @Size( max = 50 , message = "#i18n{uploadimage.validation.options.Rotate.size}" ) 
+
+    private int nMaxHeight;
+
+    @Size( max = 50, message = "#i18n{uploadimage.validation.options.Rotate.size}" )
     private String _strRatio;
-    
-    @Size( max = 50 , message = "#i18n{uploadimage.validation.options.Rotate.size}" ) 
+
+    @Size( max = 50, message = "#i18n{uploadimage.validation.options.Rotate.size}" )
     private String _strFieldName;
 
     /**
      * Returns the Id
+     *
      * @return The Id
      */
     public int getId( )
@@ -104,8 +107,10 @@ public class Options
 
     /**
      * Sets the Id
-     * @param nId The Id
-     */ 
+     *
+     * @param nId
+     *         The Id
+     */
     public void setId( int nId )
     {
         _nId = nId;
@@ -113,6 +118,7 @@ public class Options
 
     /**
      * Returns the Strict
+     *
      * @return The Strict
      */
     public boolean getStrict( )
@@ -122,14 +128,18 @@ public class Options
 
     /**
      * Sets the Strict
-     * @param bStrict The Strict
-     */ 
+     *
+     * @param bStrict
+     *         The Strict
+     */
     public void setStrict( boolean bStrict )
     {
         _bStrict = bStrict;
     }
+
     /**
      * Returns the Responsive
+     *
      * @return The Responsive
      */
     public boolean getResponsive( )
@@ -139,14 +149,18 @@ public class Options
 
     /**
      * Sets the Responsive
-     * @param bResponsive The Responsive
-     */ 
+     *
+     * @param bResponsive
+     *         The Responsive
+     */
     public void setResponsive( boolean bResponsive )
     {
         _bResponsive = bResponsive;
     }
+
     /**
      * Returns the CheckImageOrigin
+     *
      * @return The CheckImageOrigin
      */
     public boolean getCheckImageOrigin( )
@@ -156,14 +170,18 @@ public class Options
 
     /**
      * Sets the CheckImageOrigin
-     * @param bCheckImageOrigin The CheckImageOrigin
-     */ 
+     *
+     * @param bCheckImageOrigin
+     *         The CheckImageOrigin
+     */
     public void setCheckImageOrigin( boolean bCheckImageOrigin )
     {
         _bCheckImageOrigin = bCheckImageOrigin;
     }
+
     /**
      * Returns the Modal
+     *
      * @return The Modal
      */
     public boolean getModal( )
@@ -173,14 +191,18 @@ public class Options
 
     /**
      * Sets the Modal
-     * @param bModal The Modal
-     */ 
+     *
+     * @param bModal
+     *         The Modal
+     */
     public void setModal( boolean bModal )
     {
         _bModal = bModal;
     }
+
     /**
      * Returns the Guides
+     *
      * @return The Guides
      */
     public boolean getGuides( )
@@ -190,14 +212,18 @@ public class Options
 
     /**
      * Sets the Guides
-     * @param bGuides The Guides
-     */ 
+     *
+     * @param bGuides
+     *         The Guides
+     */
     public void setGuides( boolean bGuides )
     {
         _bGuides = bGuides;
     }
+
     /**
      * Returns the Highlight
+     *
      * @return The Highlight
      */
     public boolean getHighlight( )
@@ -207,14 +233,18 @@ public class Options
 
     /**
      * Sets the Highlight
-     * @param bHighlight The Highlight
-     */ 
+     *
+     * @param bHighlight
+     *         The Highlight
+     */
     public void setHighlight( boolean bHighlight )
     {
         _bHighlight = bHighlight;
     }
+
     /**
      * Returns the Background
+     *
      * @return The Background
      */
     public boolean getBackground( )
@@ -224,14 +254,18 @@ public class Options
 
     /**
      * Sets the Background
-     * @param bBackground The Background
-     */ 
+     *
+     * @param bBackground
+     *         The Background
+     */
     public void setBackground( boolean bBackground )
     {
         _bBackground = bBackground;
     }
+
     /**
      * Returns the AutoCrop
+     *
      * @return The AutoCrop
      */
     public boolean getAutoCrop( )
@@ -241,14 +275,18 @@ public class Options
 
     /**
      * Sets the AutoCrop
-     * @param bAutoCrop The AutoCrop
-     */ 
+     *
+     * @param bAutoCrop
+     *         The AutoCrop
+     */
     public void setAutoCrop( boolean bAutoCrop )
     {
         _bAutoCrop = bAutoCrop;
     }
+
     /**
      * Returns the DragCrop
+     *
      * @return The DragCrop
      */
     public boolean getDragCrop( )
@@ -258,14 +296,18 @@ public class Options
 
     /**
      * Sets the DragCrop
-     * @param bDragCrop The DragCrop
-     */ 
+     *
+     * @param bDragCrop
+     *         The DragCrop
+     */
     public void setDragCrop( boolean bDragCrop )
     {
         _bDragCrop = bDragCrop;
     }
+
     /**
      * Returns the Movable
+     *
      * @return The Movable
      */
     public boolean getMovable( )
@@ -275,14 +317,18 @@ public class Options
 
     /**
      * Sets the Movable
-     * @param bMovable The Movable
-     */ 
+     *
+     * @param bMovable
+     *         The Movable
+     */
     public void setMovable( boolean bMovable )
     {
         _bMovable = bMovable;
     }
+
     /**
      * Returns the Rotatable
+     *
      * @return The Rotatable
      */
     public boolean getRotatable( )
@@ -292,14 +338,18 @@ public class Options
 
     /**
      * Sets the Rotatable
-     * @param bRotatable The Rotatable
-     */ 
+     *
+     * @param bRotatable
+     *         The Rotatable
+     */
     public void setRotatable( boolean bRotatable )
     {
         _bRotatable = bRotatable;
     }
+
     /**
      * Returns the Zoomable
+     *
      * @return The Zoomable
      */
     public boolean getZoomable( )
@@ -309,14 +359,18 @@ public class Options
 
     /**
      * Sets the Zoomable
-     * @param bZoomable The Zoomable
-     */ 
+     *
+     * @param bZoomable
+     *         The Zoomable
+     */
     public void setZoomable( boolean bZoomable )
     {
         _bZoomable = bZoomable;
     }
+
     /**
      * Returns the TouchDragZoom
+     *
      * @return The TouchDragZoom
      */
     public boolean getTouchDragZoom( )
@@ -326,14 +380,18 @@ public class Options
 
     /**
      * Sets the TouchDragZoom
-     * @param bTouchDragZoom The TouchDragZoom
-     */ 
+     *
+     * @param bTouchDragZoom
+     *         The TouchDragZoom
+     */
     public void setTouchDragZoom( boolean bTouchDragZoom )
     {
         _bTouchDragZoom = bTouchDragZoom;
     }
+
     /**
      * Returns the MouseWheelZoom
+     *
      * @return The MouseWheelZoom
      */
     public boolean getMouseWheelZoom( )
@@ -343,14 +401,18 @@ public class Options
 
     /**
      * Sets the MouseWheelZoom
-     * @param bMouseWheelZoom The MouseWheelZoom
-     */ 
+     *
+     * @param bMouseWheelZoom
+     *         The MouseWheelZoom
+     */
     public void setMouseWheelZoom( boolean bMouseWheelZoom )
     {
         _bMouseWheelZoom = bMouseWheelZoom;
     }
+
     /**
      * Returns the CropBoxMovable
+     *
      * @return The CropBoxMovable
      */
     public boolean getCropBoxMovable( )
@@ -360,14 +422,18 @@ public class Options
 
     /**
      * Sets the CropBoxMovable
-     * @param bCropBoxMovable The CropBoxMovable
-     */ 
+     *
+     * @param bCropBoxMovable
+     *         The CropBoxMovable
+     */
     public void setCropBoxMovable( boolean bCropBoxMovable )
     {
         _bCropBoxMovable = bCropBoxMovable;
     }
+
     /**
      * Returns the CropBoxResizable
+     *
      * @return The CropBoxResizable
      */
     public boolean getCropBoxResizable( )
@@ -377,14 +443,18 @@ public class Options
 
     /**
      * Sets the CropBoxResizable
-     * @param bCropBoxResizable The CropBoxResizable
-     */ 
+     *
+     * @param bCropBoxResizable
+     *         The CropBoxResizable
+     */
     public void setCropBoxResizable( boolean bCropBoxResizable )
     {
         _bCropBoxResizable = bCropBoxResizable;
     }
+
     /**
      * Returns the DoubleClickToggle
+     *
      * @return The DoubleClickToggle
      */
     public boolean getDoubleClickToggle( )
@@ -394,14 +464,18 @@ public class Options
 
     /**
      * Sets the DoubleClickToggle
-     * @param bDoubleClickToggle The DoubleClickToggle
-     */ 
+     *
+     * @param bDoubleClickToggle
+     *         The DoubleClickToggle
+     */
     public void setDoubleClickToggle( boolean bDoubleClickToggle )
     {
         _bDoubleClickToggle = bDoubleClickToggle;
     }
+
     /**
      * Returns the Width
+     *
      * @return The Width
      */
     public int getWidth( )
@@ -411,14 +485,18 @@ public class Options
 
     /**
      * Sets the Width
-     * @param nWidth The Width
-     */ 
+     *
+     * @param nWidth
+     *         The Width
+     */
     public void setWidth( int nWidth )
     {
         _nWidth = nWidth;
     }
+
     /**
      * Returns the Height
+     *
      * @return The Height
      */
     public int getHeight( )
@@ -428,14 +506,18 @@ public class Options
 
     /**
      * Sets the Height
-     * @param nHeight The Height
-     */ 
+     *
+     * @param nHeight
+     *         The Height
+     */
     public void setHeight( int nHeight )
     {
         _nHeight = nHeight;
     }
+
     /**
      * Returns the X
+     *
      * @return The X
      */
     public int getX( )
@@ -445,14 +527,18 @@ public class Options
 
     /**
      * Sets the X
-     * @param nX The X
-     */ 
+     *
+     * @param nX
+     *         The X
+     */
     public void setX( int nX )
     {
         _nX = nX;
     }
+
     /**
      * Returns the Y
+     *
      * @return The Y
      */
     public int getY( )
@@ -462,14 +548,18 @@ public class Options
 
     /**
      * Sets the Y
-     * @param nY The Y
-     */ 
+     *
+     * @param nY
+     *         The Y
+     */
     public void setY( int nY )
     {
         _nY = nY;
     }
+
     /**
      * Returns the Rotate
+     *
      * @return The Rotate
      */
     public String getRatio( )
@@ -478,16 +568,19 @@ public class Options
     }
 
     /**
-     * Sets the Rotate
-     * @param strRotate The Rotate
-     */ 
+     * Sets the ratio
+     *
+     * @param strRatio
+     *         The Ratio
+     */
     public void setRatio( String strRatio )
     {
-    	_strRatio = strRatio;
+        _strRatio = strRatio;
     }
-    
+
     /**
      * Returns the FieldName
+     *
      * @return The FieldName
      */
     public String getFieldName( )
@@ -497,11 +590,33 @@ public class Options
 
     /**
      * Sets the FieldName
-     * @param strRotate The FieldName
-     */ 
+     *
+     * @param fieldName
+     *         The FieldName
+     */
     public void setFieldName( String fieldName )
     {
-    	_strFieldName = fieldName;
+        _strFieldName = fieldName;
     }
-   
+
+    /**
+     * Returns the Max height for the image
+     *
+     * @return
+     */
+    public int getMaxHeight( )
+    {
+        return nMaxHeight;
+    }
+
+    /**
+     * Set the Max height for the image
+     *
+     * @param nMaxHeight
+     *         The max height
+     */
+    public void setMaxHeight( int nMaxHeight )
+    {
+        this.nMaxHeight = nMaxHeight;
+    }
 }

--- a/src/java/fr/paris/lutece/plugins/uploadimage/business/OptionsDAO.java
+++ b/src/java/fr/paris/lutece/plugins/uploadimage/business/OptionsDAO.java
@@ -32,7 +32,6 @@
  * License 1.0
  */
 
-
 package fr.paris.lutece.plugins.uploadimage.business;
 
 import fr.paris.lutece.portal.service.plugin.Plugin;
@@ -48,33 +47,35 @@ import java.util.Collection;
 public final class OptionsDAO implements IOptionsDAO
 {
     // Constants
-    private static final String SQL_QUERY_NEW_PK = "SELECT max( id_options ) FROM uploadimage_options";
-    private static final String SQL_QUERY_SELECT = "SELECT id_options, strict, responsive, checkImageOrigin, modal, guides, highlight, background, autoCrop, dragCrop, movable, rotatable, zoomable, touchDragZoom, mouseWheelZoom, cropBoxMovable, cropBoxResizable, doubleClickToggle, width, height, x, y, ratio, fieldName FROM uploadimage_options WHERE id_options = ?";
-    private static final String SQL_QUERY_INSERT = "INSERT INTO uploadimage_options ( id_options, strict, responsive, checkImageOrigin, modal, guides, highlight, background, autoCrop, dragCrop, movable, rotatable, zoomable, touchDragZoom, mouseWheelZoom, cropBoxMovable, cropBoxResizable, doubleClickToggle, width, height, x, y, ratio, fieldName ) VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) ";
-    private static final String SQL_QUERY_DELETE = "DELETE FROM uploadimage_options WHERE id_options = ? ";
-    private static final String SQL_QUERY_UPDATE = "UPDATE uploadimage_options SET id_options = ?, strict = ?, responsive = ?, checkImageOrigin = ?, modal = ?, guides = ?, highlight = ?, background = ?, autoCrop = ?, dragCrop = ?, movable = ?, rotatable = ?, zoomable = ?, touchDragZoom = ?, mouseWheelZoom = ?, cropBoxMovable = ?, cropBoxResizable = ?, doubleClickToggle = ?, width = ?, height = ?, x = ?, y = ?, ratio = ?, fieldName = ? WHERE id_options = ?";
-    private static final String SQL_QUERY_SELECTALL = "SELECT id_options, strict, responsive, checkImageOrigin, modal, guides, highlight, background, autoCrop, dragCrop, movable, rotatable, zoomable, touchDragZoom, mouseWheelZoom, cropBoxMovable, cropBoxResizable, doubleClickToggle, width, height, x, y, ratio, fieldName FROM uploadimage_options";
-    private static final String SQL_QUERY_SELECTALL_ID = "SELECT id_options FROM uploadimage_options";
-    private static final String SQL_QUERY_SELECT_FIELDNAME = "SELECT id_options, strict, responsive, checkImageOrigin, modal, guides, highlight, background, autoCrop, dragCrop, movable, rotatable, zoomable, touchDragZoom, mouseWheelZoom, cropBoxMovable, cropBoxResizable, doubleClickToggle, width, height, x, y, ratio, fieldName FROM uploadimage_options u WHERE u.fieldName = ?";
-    
+    private static final String SQL_QUERY_NEW_PK           = "SELECT max( id_options ) FROM uploadimage_options";
+    private static final String SQL_QUERY_SELECT           = "SELECT id_options, strict, responsive, checkImageOrigin, modal, guides, highlight, background, autoCrop, dragCrop, movable, rotatable, zoomable, touchDragZoom, mouseWheelZoom, cropBoxMovable, cropBoxResizable, doubleClickToggle, width, height, x, y, ratio, max_height, fieldName FROM uploadimage_options WHERE id_options = ?";
+    private static final String SQL_QUERY_INSERT           = "INSERT INTO uploadimage_options ( id_options, strict, responsive, checkImageOrigin, modal, guides, highlight, background, autoCrop, dragCrop, movable, rotatable, zoomable, touchDragZoom, mouseWheelZoom, cropBoxMovable, cropBoxResizable, doubleClickToggle, width, height, x, y, ratio, max_height, fieldName ) VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) ";
+    private static final String SQL_QUERY_DELETE           = "DELETE FROM uploadimage_options WHERE id_options = ? ";
+    private static final String SQL_QUERY_UPDATE           = "UPDATE uploadimage_options SET id_options = ?, strict = ?, responsive = ?, checkImageOrigin = ?, modal = ?, guides = ?, highlight = ?, background = ?, autoCrop = ?, dragCrop = ?, movable = ?, rotatable = ?, zoomable = ?, touchDragZoom = ?, mouseWheelZoom = ?, cropBoxMovable = ?, cropBoxResizable = ?, doubleClickToggle = ?, width = ?, height = ?, x = ?, y = ?, ratio = ?, max_height = ?, fieldName = ? WHERE id_options = ?";
+    private static final String SQL_QUERY_SELECTALL        = "SELECT id_options, strict, responsive, checkImageOrigin, modal, guides, highlight, background, autoCrop, dragCrop, movable, rotatable, zoomable, touchDragZoom, mouseWheelZoom, cropBoxMovable, cropBoxResizable, doubleClickToggle, width, height, x, y, ratio, max_height , fieldName FROM uploadimage_options";
+    private static final String SQL_QUERY_SELECTALL_ID     = "SELECT id_options FROM uploadimage_options";
+    private static final String SQL_QUERY_SELECT_FIELDNAME = "SELECT id_options, strict, responsive, checkImageOrigin, modal, guides, highlight, background, autoCrop, dragCrop, movable, rotatable, zoomable, touchDragZoom, mouseWheelZoom, cropBoxMovable, cropBoxResizable, doubleClickToggle, width, height, x, y, ratio, max_height, fieldName FROM uploadimage_options u WHERE u.fieldName = ?";
+
     /**
      * Generates a new primary key
-     * @param plugin The Plugin
+     *
+     * @param plugin
+     *         The Plugin
      * @return The new primary key
      */
-    public int newPrimaryKey( Plugin plugin)
+    public int newPrimaryKey( Plugin plugin )
     {
-        DAOUtil daoUtil = new DAOUtil( SQL_QUERY_NEW_PK , plugin  );
+        DAOUtil daoUtil = new DAOUtil( SQL_QUERY_NEW_PK, plugin );
         daoUtil.executeQuery( );
 
         int nKey = 1;
 
-        if( daoUtil.next( ) )
+        if ( daoUtil.next( ) )
         {
-                nKey = daoUtil.getInt( 1 ) + 1;
+            nKey = daoUtil.getInt( 1 ) + 1;
         }
 
-        daoUtil.free();
+        daoUtil.free( );
 
         return nKey;
     }
@@ -112,8 +113,9 @@ public final class OptionsDAO implements IOptionsDAO
         daoUtil.setInt( 21, options.getX( ) );
         daoUtil.setInt( 22, options.getY( ) );
         daoUtil.setString( 23, options.getRatio( ) );
-        daoUtil.setString( 24, options.getFieldName( ) );
-        
+        daoUtil.setInt( 24, options.getMaxHeight( ) );
+        daoUtil.setString( 25, options.getFieldName( ) );
+
         daoUtil.executeUpdate( );
         daoUtil.free( );
     }
@@ -125,14 +127,14 @@ public final class OptionsDAO implements IOptionsDAO
     public Options load( int nKey, Plugin plugin )
     {
         DAOUtil daoUtil = new DAOUtil( SQL_QUERY_SELECT, plugin );
-        daoUtil.setInt( 1 , nKey );
+        daoUtil.setInt( 1, nKey );
         daoUtil.executeQuery( );
 
         Options options = null;
 
         if ( daoUtil.next( ) )
         {
-            options = new Options();
+            options = new Options( );
             options.setId( daoUtil.getInt( 1 ) );
             options.setStrict( daoUtil.getBoolean( 2 ) );
             options.setResponsive( daoUtil.getBoolean( 3 ) );
@@ -156,7 +158,8 @@ public final class OptionsDAO implements IOptionsDAO
             options.setX( daoUtil.getInt( 21 ) );
             options.setY( daoUtil.getInt( 22 ) );
             options.setRatio( daoUtil.getString( 23 ) );
-            options.setFieldName( daoUtil.getString( 24 ) );
+            options.setMaxHeight( daoUtil.getInt( 24 ) );
+            options.setFieldName( daoUtil.getString( 25 ) );
         }
 
         daoUtil.free( );
@@ -170,7 +173,7 @@ public final class OptionsDAO implements IOptionsDAO
     public void delete( int nKey, Plugin plugin )
     {
         DAOUtil daoUtil = new DAOUtil( SQL_QUERY_DELETE, plugin );
-        daoUtil.setInt( 1 , nKey );
+        daoUtil.setInt( 1, nKey );
         daoUtil.executeUpdate( );
         daoUtil.free( );
     }
@@ -182,7 +185,7 @@ public final class OptionsDAO implements IOptionsDAO
     public void store( Options options, Plugin plugin )
     {
         DAOUtil daoUtil = new DAOUtil( SQL_QUERY_UPDATE, plugin );
-        
+
         daoUtil.setInt( 1, options.getId( ) );
         daoUtil.setBoolean( 2, options.getStrict( ) );
         daoUtil.setBoolean( 3, options.getResponsive( ) );
@@ -206,8 +209,9 @@ public final class OptionsDAO implements IOptionsDAO
         daoUtil.setInt( 21, options.getX( ) );
         daoUtil.setInt( 22, options.getY( ) );
         daoUtil.setString( 23, options.getRatio( ) );
-        daoUtil.setString( 24, options.getFieldName( ) );
-        daoUtil.setInt( 25, options.getId( ) );
+        daoUtil.setInt( 24, options.getMaxHeight( ) );
+        daoUtil.setString( 25, options.getFieldName( ) );
+        daoUtil.setInt( 26, options.getId( ) );
 
         daoUtil.executeUpdate( );
         daoUtil.free( );
@@ -219,14 +223,14 @@ public final class OptionsDAO implements IOptionsDAO
     @Override
     public Collection<Options> selectOptionssList( Plugin plugin )
     {
-        Collection<Options> optionsList = new ArrayList<Options>(  );
+        Collection<Options> optionsList = new ArrayList<Options>( );
         DAOUtil daoUtil = new DAOUtil( SQL_QUERY_SELECTALL, plugin );
-        daoUtil.executeQuery(  );
+        daoUtil.executeQuery( );
 
-        while ( daoUtil.next(  ) )
+        while ( daoUtil.next( ) )
         {
-            Options options = new Options(  );
-            
+            Options options = new Options( );
+
             options.setId( daoUtil.getInt( 1 ) );
             options.setStrict( daoUtil.getBoolean( 2 ) );
             options.setResponsive( daoUtil.getBoolean( 3 ) );
@@ -250,7 +254,8 @@ public final class OptionsDAO implements IOptionsDAO
             options.setX( daoUtil.getInt( 21 ) );
             options.setY( daoUtil.getInt( 22 ) );
             options.setRatio( daoUtil.getString( 23 ) );
-            options.setFieldName(daoUtil.getString( 24 ) );
+            options.setMaxHeight( daoUtil.getInt( 24 ) );
+            options.setFieldName( daoUtil.getString( 25 ) );
 
             optionsList.add( options );
         }
@@ -258,26 +263,26 @@ public final class OptionsDAO implements IOptionsDAO
         daoUtil.free( );
         return optionsList;
     }
-    
+
     /**
      * {@inheritDoc }
      */
     @Override
     public Collection<Integer> selectIdOptionssList( Plugin plugin )
     {
-            Collection<Integer> optionsList = new ArrayList<Integer>( );
-            DAOUtil daoUtil = new DAOUtil( SQL_QUERY_SELECTALL_ID, plugin );
-            daoUtil.executeQuery(  );
+        Collection<Integer> optionsList = new ArrayList<Integer>( );
+        DAOUtil daoUtil = new DAOUtil( SQL_QUERY_SELECTALL_ID, plugin );
+        daoUtil.executeQuery( );
 
-            while ( daoUtil.next(  ) )
-            {
-                optionsList.add( daoUtil.getInt( 1 ) );
-            }
+        while ( daoUtil.next( ) )
+        {
+            optionsList.add( daoUtil.getInt( 1 ) );
+        }
 
-            daoUtil.free( );
-            return optionsList;
+        daoUtil.free( );
+        return optionsList;
     }
-    
+
     /**
      * {@inheritDoc }
      */
@@ -285,14 +290,14 @@ public final class OptionsDAO implements IOptionsDAO
     public Options loadOptionByFieldName( String fieldName, Plugin plugin )
     {
         DAOUtil daoUtil = new DAOUtil( SQL_QUERY_SELECT_FIELDNAME, plugin );
-        daoUtil.setString( 1 , fieldName );
+        daoUtil.setString( 1, fieldName );
         daoUtil.executeQuery( );
 
         Options options = null;
 
         if ( daoUtil.next( ) )
         {
-            options = new Options();
+            options = new Options( );
             options.setId( daoUtil.getInt( 1 ) );
             options.setStrict( daoUtil.getBoolean( 2 ) );
             options.setResponsive( daoUtil.getBoolean( 3 ) );
@@ -316,7 +321,8 @@ public final class OptionsDAO implements IOptionsDAO
             options.setX( daoUtil.getInt( 21 ) );
             options.setY( daoUtil.getInt( 22 ) );
             options.setRatio( daoUtil.getString( 23 ) );
-            options.setFieldName( daoUtil.getString( 24 ) );
+            options.setMaxHeight( daoUtil.getInt( 24 ) );
+            options.setFieldName( daoUtil.getString( 25 ) );
         }
 
         daoUtil.free( );

--- a/src/java/fr/paris/lutece/plugins/uploadimage/resources/uploadimage_messages_fr.properties
+++ b/src/java/fr/paris/lutece/plugins/uploadimage/resources/uploadimage_messages_fr.properties
@@ -180,10 +180,11 @@ model.delete.button=Supprimer
 model.upload.button=Charger l'image
 
 option.FieldName=Nom du Champ
-option.X=X
-option.Y=Y
-option.Width=Largeur
-option.Height=Hauteur
+option.X=Position crop (X)
+option.Y=Position crop (Y)
+option.Width=Largeur crop
+option.Height=Hauteur crop
+option.maxHeight=Hauteur image max
 option.Ratio=Ratio
 optin.Action=Action
 button.retour=Retour

--- a/src/java/fr/paris/lutece/plugins/uploadimage/resources/uploadimage_messages_fr.properties
+++ b/src/java/fr/paris/lutece/plugins/uploadimage/resources/uploadimage_messages_fr.properties
@@ -223,3 +223,5 @@ description.mouseWheelZoom=Activer le zoom par la molette de la souris
 description.cropBoxMovable=Activer le d\u00e9placement de la bo\u00eete de rognage
 description.cropBoxResizable=Activer le redimensionnement de la bo\u00eete de rognage
 description.doubleClickToggle=Passer du mode rognage au mode d\u00e9placement en double-cliquant sur la poign\u00e9e de rognage
+
+image.msg.error= Veillez choisir une image.

--- a/src/java/fr/paris/lutece/plugins/uploadimage/resources/uploadimage_messages_fr.properties
+++ b/src/java/fr/paris/lutece/plugins/uploadimage/resources/uploadimage_messages_fr.properties
@@ -200,6 +200,8 @@ model.title.rotate_left=Pivoter vers la gauche
 model.title.rotate_right=Pivoter vers la droite
 model.title.clear=Masquer
 model.title.reset=R\u00e9initialiser
+model.title.supprimer=Supprimer
+model.title.supprimer.tooltip=Supprimer l'image
 
 
 description.strict=Mode strict, l'image ne peut pas sortir du conteneur

--- a/src/java/fr/paris/lutece/plugins/uploadimage/web/ManageUploadimageJspBean.java
+++ b/src/java/fr/paris/lutece/plugins/uploadimage/web/ManageUploadimageJspBean.java
@@ -51,248 +51,253 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
-
 /**
  * ManageUploadimage JSP Bean abstract class for JSP Bean
  */
-public  class ManageUploadimageJspBean extends MVCAdminJspBean
+public class ManageUploadimageJspBean extends MVCAdminJspBean
 {
     // Right
     public static final String RIGHT_MANAGEUPLOADIMAGE = "UPLOADIMAGE_MANAGEMENT";
-    
+
     private static final String PROPERTY_DEFAULT_LIST_ITEM_PER_PAGE = "uploadimage.listItems.itemsPerPage";
-    private static final String PARAMETER_PAGE_INDEX = "page_index";
-    private static final String MARK_PAGINATOR = "paginator";
-    private static final String MARK_NB_ITEMS_PER_PAGE = "nb_items_per_page";
-    private static final String MARK_LIST_OPTIONS = "list_options";
-    private static final String TEMPLATE_MANAGE_UPLOAD_IMAGE= "/admin/plugins/uploadimage/manageuploadimage_tabs.html";
-    private static final String TEMPLATE_MANAGE_VIEW_OPTION= "/admin/plugins/uploadimage/manage_option.html";
-    private static final String JSP_MANAGE_OPTIONS= "jsp/admin/plugins/uploadimage/ManageUploadimage.jsp";
-    private static final String JSP_DO_REMOVE_OPTION= "jsp/admin/plugins/uploadimage/DoRemoveOptions.jsp";
+    private static final String PARAMETER_PAGE_INDEX                = "page_index";
+    private static final String MARK_PAGINATOR                      = "paginator";
+    private static final String MARK_NB_ITEMS_PER_PAGE              = "nb_items_per_page";
+    private static final String MARK_LIST_OPTIONS                   = "list_options";
+    private static final String TEMPLATE_MANAGE_UPLOAD_IMAGE        = "/admin/plugins/uploadimage/manageuploadimage_tabs.html";
+    private static final String TEMPLATE_MANAGE_VIEW_OPTION         = "/admin/plugins/uploadimage/manage_option.html";
+    private static final String JSP_MANAGE_OPTIONS                  = "jsp/admin/plugins/uploadimage/ManageUploadimage.jsp";
+    private static final String JSP_DO_REMOVE_OPTION                = "jsp/admin/plugins/uploadimage/DoRemoveOptions.jsp";
     /* Jsp Redirect */
     private static final String JSP_REDIRECT_TO_MANAGE_UPLOAD_IMAGE = "ManageUploadimage.jsp";
     /* Messages */
-    private static final String MESSAGE_CONFIRM_REMOVE_OPTION = "uploadimage.message.confirmRemoveOption";
-    private static final String INFO_OPTION_CREATED = "uploadimage.message.option.assigned";
-    private static final String INFO_OPTION_UPDATE = "uploadimage.message.option.update";
+    private static final String MESSAGE_CONFIRM_REMOVE_OPTION       = "uploadimage.message.confirmRemoveOption";
+    private static final String INFO_OPTION_CREATED                 = "uploadimage.message.option.assigned";
+    private static final String INFO_OPTION_UPDATE                  = "uploadimage.message.option.update";
     //Parameters
-    private static final String PARAMETER_STRICT = "strict";
-    private static final String PARAMETER_RESPONSIVE = "responsive";
-    private static final String PARAMETER_CHECKIMAGEORIGIN = "checkimageorigin";
-    private static final String PARAMETER_Modal = "modal";
-    private static final String PARAMETER_GUIDES = "guides";
-    private static final String PARAMETER_HIGHLIGHT = "highlight";
-    private static final String PARAMETER_BACKGOUND = "background";
-    private static final String PARAMETER_AUTOCROP = "autocrop";
-    private static final String PARAMETER_DRAGCROP = "dragcrop";
-    private static final String PARAMETER_MOVABLE = "movable";
-    private static final String PARAMETER_ROTATABLE = "rotatable";
-    private static final String PARAMETER_ZOOMABLE= "zoomable";
-    private static final String PARAMETER_TOUCHDRAZOOM= "touchdragzoom";
-    private static final String PARAMETER_MOUSEWHEELZOOM= "mousewheelzoom";
-    private static final String PARAMETER_CROPBOXMOVABLE = "cropboxmovable";
-    private static final String PARAMETER_CROPBOXRESIZABLE = "cropboxresizable";
-    private static final String PARAMETER_DOUBLECLICKTOGGLE = "doubleclicktoggle";
-    private static final String PARAMETER_WIDTH = "width";
-    private static final String PARAMETER_HEIGHT = "height";
-    private static final String PARAMETER_X = "x";
-    private static final String PARAMETER_Y = "y";
-    private static final String PARAMETER_RATIO = "ratio";
-    private static final String PARAMATER_FIELDNAME = "fieldName";
-    private static final String PARAMETER_IDOPTION = "id_option";
+    private static final String PARAMETER_STRICT                    = "strict";
+    private static final String PARAMETER_RESPONSIVE                = "responsive";
+    private static final String PARAMETER_CHECKIMAGEORIGIN          = "checkimageorigin";
+    private static final String PARAMETER_Modal                     = "modal";
+    private static final String PARAMETER_GUIDES                    = "guides";
+    private static final String PARAMETER_HIGHLIGHT                 = "highlight";
+    private static final String PARAMETER_BACKGOUND                 = "background";
+    private static final String PARAMETER_AUTOCROP                  = "autocrop";
+    private static final String PARAMETER_DRAGCROP                  = "dragcrop";
+    private static final String PARAMETER_MOVABLE                   = "movable";
+    private static final String PARAMETER_ROTATABLE                 = "rotatable";
+    private static final String PARAMETER_ZOOMABLE                  = "zoomable";
+    private static final String PARAMETER_TOUCHDRAZOOM              = "touchdragzoom";
+    private static final String PARAMETER_MOUSEWHEELZOOM            = "mousewheelzoom";
+    private static final String PARAMETER_CROPBOXMOVABLE            = "cropboxmovable";
+    private static final String PARAMETER_CROPBOXRESIZABLE          = "cropboxresizable";
+    private static final String PARAMETER_DOUBLECLICKTOGGLE         = "doubleclicktoggle";
+    private static final String PARAMETER_WIDTH                     = "width";
+    private static final String PARAMETER_HEIGHT                    = "height";
+    private static final String PARAMETER_X                         = "x";
+    private static final String PARAMETER_Y                         = "y";
+    private static final String PARAMETER_RATIO                     = "ratio";
+    private static final String PARAMATER_FIELDNAME                 = "fieldName";
+    private static final String PARAMETER_IDOPTION                  = "id_option";
+    private static final String PARAMETER_MAX_HEIGHT                = "maxHeight";
 
     //Variables
-    private int _nDefaultItemsPerPage;
+    private int    _nDefaultItemsPerPage;
     private String _strCurrentPageIndex;
-    private int _nItemsPerPage;
+    private int    _nItemsPerPage;
 
-    protected Map<String, Object> getPaginatedListModel( HttpServletRequest request, String strBookmark, List list,
-        String strManageJsp )
+    protected Map<String, Object> getPaginatedListModel( HttpServletRequest request, String strBookmark, List list, String strManageJsp )
     {
         _strCurrentPageIndex = Paginator.getPageIndex( request, Paginator.PARAMETER_PAGE_INDEX, _strCurrentPageIndex );
         _nDefaultItemsPerPage = AppPropertiesService.getPropertyInt( PROPERTY_DEFAULT_LIST_ITEM_PER_PAGE, 50 );
-        _nItemsPerPage = Paginator.getItemsPerPage( request, Paginator.PARAMETER_ITEMS_PER_PAGE, _nItemsPerPage,
-                _nDefaultItemsPerPage );
+        _nItemsPerPage = Paginator.getItemsPerPage( request, Paginator.PARAMETER_ITEMS_PER_PAGE, _nItemsPerPage, _nDefaultItemsPerPage );
 
         UrlItem url = new UrlItem( strManageJsp );
-        String strUrl = url.getUrl(  );
+        String strUrl = url.getUrl( );
 
         // PAGINATOR
-        LocalizedPaginator paginator = new LocalizedPaginator( list, _nItemsPerPage, strUrl, PARAMETER_PAGE_INDEX,
-                _strCurrentPageIndex, getLocale(  ) );
+        LocalizedPaginator paginator = new LocalizedPaginator( list, _nItemsPerPage, strUrl, PARAMETER_PAGE_INDEX, _strCurrentPageIndex, getLocale( ) );
 
-        Map<String, Object> model = getModel(  );
+        Map<String, Object> model = getModel( );
 
         model.put( MARK_NB_ITEMS_PER_PAGE, "" + _nItemsPerPage );
         model.put( MARK_PAGINATOR, paginator );
-        model.put( strBookmark, paginator.getPageItems(  ) );
+        model.put( strBookmark, paginator.getPageItems( ) );
 
         return model;
     }
-    
+
     /**
      * get form to import file
+     *
      * @param request
      * @return view of formulaire
      */
-   public String getManageUploadimageHome ( HttpServletRequest request ){
-	   
-	   _strCurrentPageIndex = Paginator.getPageIndex( request, Paginator.PARAMETER_PAGE_INDEX, _strCurrentPageIndex );
-       _nDefaultItemsPerPage = AppPropertiesService.getPropertyInt( PROPERTY_DEFAULT_LIST_ITEM_PER_PAGE, 50 );
-       _nItemsPerPage = Paginator.getItemsPerPage( request, Paginator.PARAMETER_ITEMS_PER_PAGE, _nItemsPerPage,
-               _nDefaultItemsPerPage );
-       
-	   Collection<Options> options = OptionsHome.getOptionssList(  );
+    public String getManageUploadimageHome( HttpServletRequest request )
+    {
 
-       // PAGINATOR
-       LocalizedPaginator paginator = new LocalizedPaginator( (List) options, _nItemsPerPage, getUrlPage(  ), PARAMETER_PAGE_INDEX,
-               _strCurrentPageIndex, getLocale(  ) );
-      
+        _strCurrentPageIndex = Paginator.getPageIndex( request, Paginator.PARAMETER_PAGE_INDEX, _strCurrentPageIndex );
+        _nDefaultItemsPerPage = AppPropertiesService.getPropertyInt( PROPERTY_DEFAULT_LIST_ITEM_PER_PAGE, 50 );
+        _nItemsPerPage = Paginator.getItemsPerPage( request, Paginator.PARAMETER_ITEMS_PER_PAGE, _nItemsPerPage, _nDefaultItemsPerPage );
 
-       Map<String, Object> model = getModel(  );
+        Collection<Options> options = OptionsHome.getOptionssList( );
 
-       model.put( MARK_NB_ITEMS_PER_PAGE, "" + _nItemsPerPage );
-       model.put( MARK_PAGINATOR, paginator );
-	   model.put( MARK_LIST_OPTIONS, paginator.getPageItems( ));
+        // PAGINATOR
+        LocalizedPaginator paginator = new LocalizedPaginator( ( List ) options, _nItemsPerPage, getUrlPage( ), PARAMETER_PAGE_INDEX, _strCurrentPageIndex, getLocale( ) );
 
-       HtmlTemplate templateList = AppTemplateService.getTemplate( TEMPLATE_MANAGE_UPLOAD_IMAGE, getLocale(  ), model );
+        Map<String, Object> model = getModel( );
 
-       return getAdminPage( templateList.getHtml(  ) );
-   }
-   
-   public String manageOptions( HttpServletRequest request ){
-	   
-	   boolean bStrict = Boolean.parseBoolean(request.getParameter(PARAMETER_STRICT));
-	   boolean bResponsive = Boolean.parseBoolean(request.getParameter(PARAMETER_RESPONSIVE));
-	   boolean bCheckImageOrigin = Boolean.parseBoolean(request.getParameter(PARAMETER_CHECKIMAGEORIGIN));
-	   boolean bModal = Boolean.parseBoolean(request.getParameter(PARAMETER_Modal));
-	   boolean bGuides = Boolean.parseBoolean(request.getParameter(PARAMETER_GUIDES));
-	   boolean bHighlight = Boolean.parseBoolean(request.getParameter(PARAMETER_HIGHLIGHT));
-	   boolean bBackground = Boolean.parseBoolean(request.getParameter(PARAMETER_BACKGOUND));
-	   boolean bAutocrop = Boolean.parseBoolean(request.getParameter(PARAMETER_AUTOCROP));
-	   boolean bDragCrop = Boolean.parseBoolean(request.getParameter(PARAMETER_DRAGCROP));
-	   boolean bMovable = Boolean.parseBoolean(request.getParameter(PARAMETER_MOVABLE));
-	   boolean bRotatable = Boolean.parseBoolean(request.getParameter(PARAMETER_ROTATABLE));
-	   boolean bZoomable = Boolean.parseBoolean(request.getParameter(PARAMETER_ZOOMABLE));
-	   boolean bTouchDragZoom = Boolean.parseBoolean(request.getParameter(PARAMETER_TOUCHDRAZOOM));
-	   boolean bMouseWheelZoom = Boolean.parseBoolean(request.getParameter(PARAMETER_MOUSEWHEELZOOM));
-	   boolean bCropBoxMovable = Boolean.parseBoolean(request.getParameter(PARAMETER_CROPBOXMOVABLE));
-	   boolean bCropBoxResizable = Boolean.parseBoolean(request.getParameter(PARAMETER_CROPBOXRESIZABLE));
-	   boolean bDoubleClickToggle = Boolean.parseBoolean(request.getParameter(PARAMETER_DOUBLECLICKTOGGLE));
-	 
-	   int nWidth = Integer.parseInt(request.getParameter(PARAMETER_WIDTH));
-	   int nHeight = Integer.parseInt(request.getParameter(PARAMETER_HEIGHT));
-	   int nX = Integer.parseInt(request.getParameter(PARAMETER_X));
-	   int nY = Integer.parseInt(request.getParameter(PARAMETER_Y));
-	   
-	   String strId = request.getParameter(PARAMETER_IDOPTION);
-	   
-	   String strRatio = request.getParameter(PARAMETER_RATIO);
-	   String strFieldName = request.getParameter(PARAMATER_FIELDNAME);
-	   
-	   String action= request.getParameter("action");
-	   
-	   Options option= new Options();
-	   
-	   option.setAutoCrop(bAutocrop);
-	   option.setBackground(bBackground);
-	   option.setCheckImageOrigin(bCheckImageOrigin);
-	   option.setCropBoxMovable(bCropBoxMovable);
-	   option.setDoubleClickToggle(bDoubleClickToggle);
-	   option.setDragCrop(bDragCrop);
-	   option.setGuides(bGuides);
-	   option.setHighlight(bHighlight);
-	   option.setModal(bModal);
-	   option.setMouseWheelZoom(bMouseWheelZoom);
-	   option.setMovable(bMovable);
-	   option.setResponsive(bResponsive);
-	   option.setRotatable(bRotatable);
-	   option.setStrict(bStrict);
-	   option.setTouchDragZoom(bTouchDragZoom);
-	   option.setZoomable(bZoomable);
-	   option.setCropBoxResizable(bCropBoxResizable);
-	   
-	   option.setHeight(nHeight);
-	   option.setWidth(nWidth);
-	   option.setX(nX);
-	   option.setY(nY);
-	   option.setRatio(strRatio);
-	   option.setFieldName(strFieldName);
-	   
-	   if(action.equals("modify_option")){
-		   option.setId(Integer.parseInt(strId));
-		   OptionsHome.update(option);
-		   addInfo( INFO_OPTION_CREATED, getLocale(  ) );
-	   }
-	   else{
-		   OptionsHome.create(option);
-		   addInfo( INFO_OPTION_UPDATE, getLocale(  ) );
-	   }
-	   
-	   Map<String, Object> model = getModel(  );
-	   model.put("option", option);  
-	   model.put("action", "modify_option");
-	   
-	   
-	   return getManageUploadimageHome(request);
-   }
-  
-   public String getViewOptions ( HttpServletRequest request ){
-	   
-	   String nKey= request.getParameter(PARAMETER_IDOPTION);
-	   String strAction= request.getParameter("action");
-	   Options option= new Options( );
-	   if(nKey != null){
-		   option=OptionsHome.findByPrimaryKey(Integer.parseInt(nKey));
-		  
-	   }else{
-		   option.setHeight(576);
-		   option.setWidth(1024);
-		   option.setX(128);
-		   option.setY(72);
-		   option.setRatio("16/9");   
-	   }
-	   Map<String, Object> model = getModel(  );
-	   model.put("option", option);  
-	   model.put("action", strAction);
-	   HtmlTemplate template = AppTemplateService.getTemplate( TEMPLATE_MANAGE_VIEW_OPTION, request.getLocale(  ),
-               model );
-	   
-	   return template.getHtml(  );
-   }
-   
-   /**
-    * Manages the removal form of a options whose identifier is in the http
-    * request
-    * @return the HTML code to confirm
-    * @param request The HTTP request
-    */
-   public String getConfirmRemoveOption( HttpServletRequest request )
-   {
-	   String nKey= request.getParameter(PARAMETER_IDOPTION);
-	   UrlItem url = new UrlItem( JSP_DO_REMOVE_OPTION );
-       url.addParameter( PARAMETER_IDOPTION, nKey );
-       
-       return AdminMessageService.getMessageUrl( request, MESSAGE_CONFIRM_REMOVE_OPTION, url.getUrl(  ),
-               AdminMessage.TYPE_CONFIRMATION );
+        model.put( MARK_NB_ITEMS_PER_PAGE, "" + _nItemsPerPage );
+        model.put( MARK_PAGINATOR, paginator );
+        model.put( MARK_LIST_OPTIONS, paginator.getPageItems( ) );
 
-   }
-   
-   public String removeOptions ( HttpServletRequest request ){
-	   
-	   String nKey= request.getParameter(PARAMETER_IDOPTION);
-	   if(nKey != null){
-		   OptionsHome.remove(Integer.parseInt(nKey));	  
-	   }
-	 
-	   return JSP_REDIRECT_TO_MANAGE_UPLOAD_IMAGE;
-   }
-   
-   private String getUrlPage(  )
-   {
-       UrlItem url = new UrlItem( JSP_MANAGE_OPTIONS );
+        HtmlTemplate templateList = AppTemplateService.getTemplate( TEMPLATE_MANAGE_UPLOAD_IMAGE, getLocale( ), model );
 
-       return url.getUrl(  );
-   }
+        return getAdminPage( templateList.getHtml( ) );
+    }
+
+    public String manageOptions( HttpServletRequest request )
+    {
+
+        boolean bStrict = Boolean.parseBoolean( request.getParameter( PARAMETER_STRICT ) );
+        boolean bResponsive = Boolean.parseBoolean( request.getParameter( PARAMETER_RESPONSIVE ) );
+        boolean bCheckImageOrigin = Boolean.parseBoolean( request.getParameter( PARAMETER_CHECKIMAGEORIGIN ) );
+        boolean bModal = Boolean.parseBoolean( request.getParameter( PARAMETER_Modal ) );
+        boolean bGuides = Boolean.parseBoolean( request.getParameter( PARAMETER_GUIDES ) );
+        boolean bHighlight = Boolean.parseBoolean( request.getParameter( PARAMETER_HIGHLIGHT ) );
+        boolean bBackground = Boolean.parseBoolean( request.getParameter( PARAMETER_BACKGOUND ) );
+        boolean bAutocrop = Boolean.parseBoolean( request.getParameter( PARAMETER_AUTOCROP ) );
+        boolean bDragCrop = Boolean.parseBoolean( request.getParameter( PARAMETER_DRAGCROP ) );
+        boolean bMovable = Boolean.parseBoolean( request.getParameter( PARAMETER_MOVABLE ) );
+        boolean bRotatable = Boolean.parseBoolean( request.getParameter( PARAMETER_ROTATABLE ) );
+        boolean bZoomable = Boolean.parseBoolean( request.getParameter( PARAMETER_ZOOMABLE ) );
+        boolean bTouchDragZoom = Boolean.parseBoolean( request.getParameter( PARAMETER_TOUCHDRAZOOM ) );
+        boolean bMouseWheelZoom = Boolean.parseBoolean( request.getParameter( PARAMETER_MOUSEWHEELZOOM ) );
+        boolean bCropBoxMovable = Boolean.parseBoolean( request.getParameter( PARAMETER_CROPBOXMOVABLE ) );
+        boolean bCropBoxResizable = Boolean.parseBoolean( request.getParameter( PARAMETER_CROPBOXRESIZABLE ) );
+        boolean bDoubleClickToggle = Boolean.parseBoolean( request.getParameter( PARAMETER_DOUBLECLICKTOGGLE ) );
+
+        int nWidth = Integer.parseInt( request.getParameter( PARAMETER_WIDTH ) );
+        int nHeight = Integer.parseInt( request.getParameter( PARAMETER_HEIGHT ) );
+        int nX = Integer.parseInt( request.getParameter( PARAMETER_X ) );
+        int nY = Integer.parseInt( request.getParameter( PARAMETER_Y ) );
+        int nMaxHeight = Integer.parseInt( request.getParameter( PARAMETER_MAX_HEIGHT ) );
+
+        String strId = request.getParameter( PARAMETER_IDOPTION );
+
+        String strRatio = request.getParameter( PARAMETER_RATIO );
+        String strFieldName = request.getParameter( PARAMATER_FIELDNAME );
+
+        String action = request.getParameter( "action" );
+
+        Options option = new Options( );
+
+        option.setAutoCrop( bAutocrop );
+        option.setBackground( bBackground );
+        option.setCheckImageOrigin( bCheckImageOrigin );
+        option.setCropBoxMovable( bCropBoxMovable );
+        option.setDoubleClickToggle( bDoubleClickToggle );
+        option.setDragCrop( bDragCrop );
+        option.setGuides( bGuides );
+        option.setHighlight( bHighlight );
+        option.setModal( bModal );
+        option.setMouseWheelZoom( bMouseWheelZoom );
+        option.setMovable( bMovable );
+        option.setResponsive( bResponsive );
+        option.setRotatable( bRotatable );
+        option.setStrict( bStrict );
+        option.setTouchDragZoom( bTouchDragZoom );
+        option.setZoomable( bZoomable );
+        option.setCropBoxResizable( bCropBoxResizable );
+
+        option.setHeight( nHeight );
+        option.setWidth( nWidth );
+        option.setX( nX );
+        option.setY( nY );
+        option.setRatio( strRatio );
+        option.setFieldName( strFieldName );
+        option.setMaxHeight( nMaxHeight );
+
+        if ( action.equals( "modify_option" ) )
+        {
+            option.setId( Integer.parseInt( strId ) );
+            OptionsHome.update( option );
+            addInfo( INFO_OPTION_CREATED, getLocale( ) );
+        } else
+        {
+            OptionsHome.create( option );
+            addInfo( INFO_OPTION_UPDATE, getLocale( ) );
+        }
+
+        Map<String, Object> model = getModel( );
+        model.put( "option", option );
+        model.put( "action", "modify_option" );
+
+        return getManageUploadimageHome( request );
+    }
+
+    public String getViewOptions( HttpServletRequest request )
+    {
+
+        String nKey = request.getParameter( PARAMETER_IDOPTION );
+        String strAction = request.getParameter( "action" );
+        Options option = new Options( );
+        if ( nKey != null )
+        {
+            option = OptionsHome.findByPrimaryKey( Integer.parseInt( nKey ) );
+
+        } else
+        {
+            option.setHeight( 576 );
+            option.setWidth( 1024 );
+            option.setX( 128 );
+            option.setY( 72 );
+            option.setRatio( "16/9" );
+            option.setMaxHeight( 1000 );
+        }
+        Map<String, Object> model = getModel( );
+        model.put( "option", option );
+        model.put( "action", strAction );
+        HtmlTemplate template = AppTemplateService.getTemplate( TEMPLATE_MANAGE_VIEW_OPTION, request.getLocale( ), model );
+
+        return template.getHtml( );
+    }
+
+    /**
+     * Manages the removal form of a options whose identifier is in the http
+     * request
+     *
+     * @param request
+     *         The HTTP request
+     * @return the HTML code to confirm
+     */
+    public String getConfirmRemoveOption( HttpServletRequest request )
+    {
+        String nKey = request.getParameter( PARAMETER_IDOPTION );
+        UrlItem url = new UrlItem( JSP_DO_REMOVE_OPTION );
+        url.addParameter( PARAMETER_IDOPTION, nKey );
+
+        return AdminMessageService.getMessageUrl( request, MESSAGE_CONFIRM_REMOVE_OPTION, url.getUrl( ), AdminMessage.TYPE_CONFIRMATION );
+
+    }
+
+    public String removeOptions( HttpServletRequest request )
+    {
+
+        String nKey = request.getParameter( PARAMETER_IDOPTION );
+        if ( nKey != null )
+        {
+            OptionsHome.remove( Integer.parseInt( nKey ) );
+        }
+
+        return JSP_REDIRECT_TO_MANAGE_UPLOAD_IMAGE;
+    }
+
+    private String getUrlPage( )
+    {
+        UrlItem url = new UrlItem( JSP_MANAGE_OPTIONS );
+
+        return url.getUrl( );
+    }
 
 }

--- a/src/java/fr/paris/lutece/plugins/uploadimage/web/UploadimageApp.java
+++ b/src/java/fr/paris/lutece/plugins/uploadimage/web/UploadimageApp.java
@@ -1,36 +1,36 @@
 /*
- * Copyright (c) 2002-2015, Mairie de Paris
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *  1. Redistributions of source code must retain the above copyright notice
- *     and the following disclaimer.
- *
- *  2. Redistributions in binary form must reproduce the above copyright notice
- *     and the following disclaimer in the documentation and/or other materials
- *     provided with the distribution.
- *
- *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
- *     contributors may be used to endorse or promote products derived from
- *     this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
- * License 1.0
- */
+* Copyright (c) 2002-2015, Mairie de Paris
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+*  1. Redistributions of source code must retain the above copyright notice
+*     and the following disclaimer.
+*
+*  2. Redistributions in binary form must reproduce the above copyright notice
+*     and the following disclaimer in the documentation and/or other materials
+*     provided with the distribution.
+*
+*  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+*     contributors may be used to endorse or promote products derived from
+*     this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+* License 1.0
+*/
 package fr.paris.lutece.plugins.uploadimage.web;
 
 import java.util.HashMap;
@@ -39,6 +39,7 @@ import java.util.Map;
 import fr.paris.lutece.plugins.uploadimage.business.Options;
 import fr.paris.lutece.plugins.uploadimage.business.OptionsHome;
 import fr.paris.lutece.plugins.uploadimage.service.UploadImageCacheService;
+import fr.paris.lutece.portal.service.i18n.I18nService;
 import fr.paris.lutece.portal.web.xpages.XPage;
 import fr.paris.lutece.portal.service.template.AppTemplateService;
 import fr.paris.lutece.portal.service.util.AppPathService;
@@ -54,104 +55,100 @@ import org.apache.commons.lang.StringUtils;
 /**
  * This class provides a simple implementation of an XPage
  */
- 
-@Controller( xpageName = "uploadimage" , pageTitleI18nKey = "uploadimage.xpage.uploadimage.pageTitle" , pagePathI18nKey = "uploadimage.xpage.uploadimage.pagePathLabel" )
+
+@Controller( xpageName = "uploadimage", pageTitleI18nKey = "uploadimage.xpage.uploadimage.pageTitle", pagePathI18nKey = "uploadimage.xpage.uploadimage.pagePathLabel" )
 public class UploadimageApp extends MVCApplication
 {
-    private static final String TEMPLATE_XPAGE = "/skin/plugins/uploadimage/uploadimageXpage.html";
- // Templates
+    private static final String TEMPLATE_XPAGE                = "/skin/plugins/uploadimage/uploadimageXpage.html";
+    // TEMPLATES
     private static final String TEMPLATE_MAIN_UPLOAD_IMAGE_JS = "skin/plugins/uploadimage/main.js";
-    
-    private static final String VIEW_HOME = "home";
-    
-    private static final String IDOPTION = "id_option";
-    
-    private static final String MARK_FIELDNAME = "fieldName";
-    private static final String PARAMATER_FIELDNAME = "fieldName";
-    
+    //VIEW
+    private static final String VIEW_HOME                     = "home";
+    // PARAM
+    private static final String PARAMATER_FIELDNAME           = "fieldName";
+    //MARKER
+    private static final String MARK_FIELDNAME                = "fieldName";
+    public static final  String MARK_OPTION                   = "option";
+    public static final  String MARK_BASE_URL                 = "MARK_BASE_URL";
+    private static final String MARK_ERROR_MSG                = "errorMsg";
+
     /**
-     * Returns the content of the page uploadimage. 
-     * @param request The HTTP request
+     * Returns the content of the page uploadimage.
+     *
+     * @param request
+     *         The HTTP request
      * @return The view
      */
-    @View( value = VIEW_HOME , defaultView = true )
+    @View( value = VIEW_HOME, defaultView = true )
     public XPage viewHome( HttpServletRequest request )
     {
-    	Map<String, Object> model = new HashMap<String, Object>(  );
-    //	model.put("main", getMainUploadJs(request));
-        return getXPage( TEMPLATE_XPAGE, request.getLocale(  ), model );
+        Map<String, Object> model = new HashMap<>( );
+        return getXPage( TEMPLATE_XPAGE, request.getLocale( ), model );
     }
-    
-    
+
     public String getMainUploadJs( HttpServletRequest request )
-    
+
     {
-    	
-    	//String nId = request.getParameter(IDOPTION);
-    	String strFieldname = request.getParameter(PARAMATER_FIELDNAME);
-    	Options option= new Options( );
-    	
- 	   if(strFieldname != null && !strFieldname.isEmpty( )){
- 		   option=OptionsHome.findByFieldName(strFieldname);  
- 	   }else{
- 		   option= getDefaultOption(	);
- 	   }
- 	   if(option == null ){
- 		   option= getDefaultOption(  );
- 	   }
-   
-    	 String strKey = "clef";
-    	
-    	 String strContent = (String) UploadImageCacheService.getInstance(  ).getFromCache( strKey );
-       
 
-       //  if ( strContent == null )
-        // {
-	    	 Map<String, Object> model = new HashMap<String, Object>(  );
-	    	 model.put( "MARK_BASE_URL"," strBaseUrl" );
-	    	 model.put("option", option);
-	    	 model.put(MARK_FIELDNAME, strFieldname);
-	    	 
-	         HtmlTemplate template = AppTemplateService.getTemplate( TEMPLATE_MAIN_UPLOAD_IMAGE_JS, request.getLocale(  ),
-	                    model );
-	         strContent = template.getHtml(  );
-	      //      UploadImageCacheService.getInstance(  ).putInCache( strKey, strContent );
-        //}
+        String strFieldname = request.getParameter( PARAMATER_FIELDNAME );
+        Options option;
 
-        return strContent;
+        if ( strFieldname != null && !strFieldname.isEmpty( ) )
+        {
+            option = OptionsHome.findByFieldName( strFieldname );
+        } else
+        {
+            option = getDefaultOption( );
+        }
+        if ( option == null )
+        {
+            option = getDefaultOption( );
+        }
+
+        Map<String, Object> model = new HashMap<>( );
+        model.put( MARK_BASE_URL, " strBaseUrl" );
+        model.put( MARK_OPTION, option );
+        model.put( MARK_FIELDNAME, strFieldname );
+        model.put( MARK_ERROR_MSG, I18nService.getLocalizedString( "uploadimage.image.msg.error", request.getLocale( ) ) );
+
+        HtmlTemplate template = AppTemplateService.getTemplate( TEMPLATE_MAIN_UPLOAD_IMAGE_JS, request.getLocale( ), model );
+
+        return template.getHtml( );
+
     }
-    
-    private Options getDefaultOption(	){
-    	
-    	Options option= new Options( );
-    	
-       option.setAutoCrop(true);
-  	   option.setBackground(true);
-  	   option.setCheckImageOrigin(true);
-  	   option.setCropBoxMovable(true);
-  	   option.setDoubleClickToggle(true);
-  	   option.setDragCrop(true);
-  	   option.setGuides(true);
-  	   option.setHighlight(true);
-  	   option.setModal(true);
-  	   option.setMouseWheelZoom(true);
-  	   option.setMovable(true);
-  	   option.setResponsive(true);
-  	   option.setRotatable(true);
-  	   option.setStrict(true);
-  	   option.setTouchDragZoom(true);
-  	   option.setZoomable(true);
-  	   option.setCropBoxResizable(true);
-  	   
-  	   option.setHeight(576);
-  	   option.setWidth(1024);
-  	   option.setX(128);
-  	   option.setY(72);
-  	   option.setRatio("16/9");
-  	   option.setFieldName("fieldName");
-  	   
-  	   return option;
-    	
+
+    private Options getDefaultOption( )
+    {
+
+        Options option = new Options( );
+
+        option.setAutoCrop( true );
+        option.setBackground( true );
+        option.setCheckImageOrigin( true );
+        option.setCropBoxMovable( true );
+        option.setDoubleClickToggle( true );
+        option.setDragCrop( true );
+        option.setGuides( true );
+        option.setHighlight( true );
+        option.setModal( true );
+        option.setMouseWheelZoom( true );
+        option.setMovable( true );
+        option.setResponsive( true );
+        option.setRotatable( true );
+        option.setStrict( true );
+        option.setTouchDragZoom( true );
+        option.setZoomable( true );
+        option.setCropBoxResizable( true );
+
+        option.setHeight( 576 );
+        option.setWidth( 1024 );
+        option.setX( 128 );
+        option.setY( 72 );
+        option.setRatio( "16/9" );
+        option.setFieldName( "fieldName" );
+
+        return option;
+
     }
 
 }

--- a/src/sql/plugins/uploadimage/plugin/upgrade_1.0.1.sql
+++ b/src/sql/plugins/uploadimage/plugin/upgrade_1.0.1.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `a22_carte_citoyen`.`uploadimage_options`
+ADD COLUMN `max_height` INT(11) NOT NULL DEFAULT 1000 AFTER `fieldName`;

--- a/webapp/WEB-INF/templates/admin/plugins/uploadimage/manage_option.html
+++ b/webapp/WEB-INF/templates/admin/plugins/uploadimage/manage_option.html
@@ -1,159 +1,183 @@
-	<@uploadImage />
-	<#macro uploadImage >
-	<div class="container">
-	<legend>#i18n{uploadimage.manage.option.crop}</legend>
-	<form class="form-horizontal" method="post" action="jsp/admin/plugins/uploadimage/ManageOptions.jsp">
-		<@messages errors=errors /> <@messages infos=infos />
-		<input  type="hidden" name="action" id="action" value="${action!}"/>
+<@uploadImage />
+<#macro uploadImage >
+<div class="container">
+    <legend>#i18n{uploadimage.manage.option.crop}</legend>
+    <form class="form-horizontal" method="post" action="jsp/admin/plugins/uploadimage/ManageOptions.jsp">
+        <@messages errors=errors /> <@messages infos=infos />
+        <input type="hidden" name="action" id="action" value="${action!}"/>
+
         <div class="">
-		<input  type="hidden" name="id_option" id="id_option" value="${option.id!}"/>
-          
-          <ul class="" role="menu" aria-labelledby="toggleOptions">
-            <li role="presentation">
-              <label class="checkbox-inline">
-		
-                <input type="checkbox" name="strict" value="true" <#if option.strict> checked </#if> > 
-                 <span class='badge' >strict</span> <small>#i18n{uploadimage.description.strict}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="responsive" value="true" <#if option.responsive> checked </#if> > 
-                 <span class='badge' >responsive</span> <small>#i18n{uploadimage.description.responsive}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="checkimageorigin" value="true" <#if option.checkImageOrigin> checked </#if> >
-                <span class='badge' >checkImageOrigin</span> <small>#i18n{uploadimage.description.checkImageOrigin}</small>
-              </label>
-            </li>
+            <input type="hidden" name="id_option" id="id_option" value="${option.id!}"/>
 
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="modal" value="true" <#if option.modal> checked </#if>> 
-                <span class='badge' >modal</span> <small>#i18n{uploadimage.description.modal}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="guides" value="true" <#if option.guides> checked </#if>> 
-                <span class='badge' >guides</span> <small>#i18n{uploadimage.description.guides}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="highlight" value="true" <#if option.highlight> checked </#if>> 
-                <span class='badge' >highlight</span> <small>#i18n{uploadimage.description.highlight}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="background" value="true" <#if option.background> checked </#if>> 
-                <span class='badge' >background</span> <small>#i18n{uploadimage.description.background}</small>
-              </label>
-            </li>
+            <ul class="" role="menu" aria-labelledby="toggleOptions">
+                <li role="presentation">
+                    <label class="checkbox-inline">
 
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="autocrop" value="true" <#if option.autoCrop> checked </#if>> 
-                <span class='badge' >autoCrop</span> <small>#i18n{uploadimage.description.autoCrop}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="dragcrop" value="true" <#if option.dragCrop> checked </#if>> 
-                <span class='badge' >dragCrop</span> <small>#i18n{uploadimage.description.dragCrop}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="movable" value="true" <#if option.movable> checked </#if>>
-                <span class='badge' >movable</span> <small>#i18n{uploadimage.description.movable}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="rotatable" value="true" <#if option.rotatable> checked </#if>>
-                <span class='badge' >rotatable</span> <small>#i18n{uploadimage.description.rotatable}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="zoomable" value="true" <#if option.zoomable> checked </#if>>
-                <span class='badge' >zoomable</span> <small>#i18n{uploadimage.description.zoomable}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="touchdragzoom" value="true" <#if option.touchDragZoom> checked </#if>>
-                <span class='badge' >touchDragZoom</span> <small>#i18n{uploadimage.description.touchDragZoom}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="mousewheelzoom" value="true" <#if option.mouseWheelZoom> checked </#if>> 
-                <span class='badge' >mouseWheelZoom</span> <small>#i18n{uploadimage.description.mouseWheelZoom}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="cropboxmovable" value="true" <#if option.cropBoxMovable> checked </#if>> 
-                <span class='badge' >cropBoxMovable</span> <small>#i18n{uploadimage.description.cropBoxMovable}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="cropboxresizable" value="true" <#if option.cropBoxResizable> checked </#if>>
-                <span class='badge' >cropBoxResizable</span> <small>#i18n{uploadimage.description.cropBoxResizable}</small>
-              </label>
-            </li>
-            <li role="presentation">
-              <label class="checkbox-inline">
-                <input type="checkbox" name="doubleclicktoggle" value="true" <#if option.doubleClickToggle> checked </#if>> 
-                <span class='badge' >doubleClickToggle</span> <small>#i18n{uploadimage.description.doubleClickToggle}</small>
-              </label>
-            </li>
-          </ul>
-        </div><!-- /.dropdown -->
- <!-- <h3 class="page-header">Data:</h3> -->
+                        <input type="checkbox" name="strict" value="true" <#if option.strict> checked </#if> >
+                        <span class='badge'>strict</span>
+                        <small>#i18n{uploadimage.description.strict}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="responsive" value="true" <#if option.responsive> checked </#if> >
+                        <span class='badge'>responsive</span>
+                        <small>#i18n{uploadimage.description.responsive}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="checkimageorigin" value="true" <#if option.checkImageOrigin> checked </#if> >
+                        <span class='badge'>checkImageOrigin</span>
+                        <small>#i18n{uploadimage.description.checkImageOrigin}</small>
+                    </label>
+                </li>
+
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="modal" value="true" <#if option.modal> checked </#if>>
+                        <span class='badge'>modal</span>
+                        <small>#i18n{uploadimage.description.modal}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="guides" value="true" <#if option.guides> checked </#if>>
+                        <span class='badge'>guides</span>
+                        <small>#i18n{uploadimage.description.guides}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="highlight" value="true" <#if option.highlight> checked </#if>>
+                        <span class='badge'>highlight</span>
+                        <small>#i18n{uploadimage.description.highlight}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="background" value="true" <#if option.background> checked </#if>>
+                        <span class='badge'>background</span>
+                        <small>#i18n{uploadimage.description.background}</small>
+                    </label>
+                </li>
+
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="autocrop" value="true" <#if option.autoCrop> checked </#if>>
+                        <span class='badge'>autoCrop</span>
+                        <small>#i18n{uploadimage.description.autoCrop}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="dragcrop" value="true" <#if option.dragCrop> checked </#if>>
+                        <span class='badge'>dragCrop</span>
+                        <small>#i18n{uploadimage.description.dragCrop}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="movable" value="true" <#if option.movable> checked </#if>>
+                        <span class='badge'>movable</span>
+                        <small>#i18n{uploadimage.description.movable}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="rotatable" value="true" <#if option.rotatable> checked </#if>>
+                        <span class='badge'>rotatable</span>
+                        <small>#i18n{uploadimage.description.rotatable}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="zoomable" value="true" <#if option.zoomable> checked </#if>>
+                        <span class='badge'>zoomable</span>
+                        <small>#i18n{uploadimage.description.zoomable}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="touchdragzoom" value="true" <#if option.touchDragZoom> checked </#if>>
+                        <span class='badge'>touchDragZoom</span>
+                        <small>#i18n{uploadimage.description.touchDragZoom}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="mousewheelzoom" value="true" <#if option.mouseWheelZoom> checked </#if>>
+                        <span class='badge'>mouseWheelZoom</span>
+                        <small>#i18n{uploadimage.description.mouseWheelZoom}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="cropboxmovable" value="true" <#if option.cropBoxMovable> checked </#if>>
+                        <span class='badge'>cropBoxMovable</span>
+                        <small>#i18n{uploadimage.description.cropBoxMovable}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="cropboxresizable" value="true" <#if option.cropBoxResizable> checked </#if>>
+                        <span class='badge'>cropBoxResizable</span>
+                        <small>#i18n{uploadimage.description.cropBoxResizable}</small>
+                    </label>
+                </li>
+                <li role="presentation">
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="doubleclicktoggle" value="true" <#if option.doubleClickToggle> checked </#if>>
+                        <span class='badge'>doubleClickToggle</span>
+                        <small>#i18n{uploadimage.description.doubleClickToggle}</small>
+                    </label>
+                </li>
+            </ul>
+        </div>
+        <br>
         <div class="docs-data">
-          <div class="input-group">
-            <label class="input-group-addon" for="dataX">#i18n{uploadimage.option.X}</label>
-            <input class="form-control" id="dataX" type="number" placeholder="x" name="x" value="${option.x!}" required>
-            <span class="input-group-addon">px</span>
-          </div>
-          <div class="input-group">
-            <label class="input-group-addon" for="dataY">#i18n{uploadimage.option.Y}</label>
-            <input class="form-control" id="dataY"  type="number" placeholder="y" name="y" value="${option.y!}" required>
-            <span class="input-group-addon">px</span>
-          </div>
-          <div class="input-group">
-            <label class="input-group-addon" for="dataWidth">#i18n{uploadimage.option.Width}</label>
-            <input class="form-control" id="dataWidth" type="number" placeholder="width" name="width" value="${option.width!}" required>
-            <span class="input-group-addon">px</span>
-          </div>
-          <div class="input-group">
-            <label class="input-group-addon" for="dataHeight">#i18n{uploadimage.option.Height}</label>
-            <input class="form-control" id="dataHeight" type="number" placeholder="height" name="height" value="${option.height!}" required>
-            <span class="input-group-addon">px</span>
-          </div>
-          <div class="input-group">
-            <label class="input-group-addon" for="dataRatio">#i18n{uploadimage.option.Ratio}</label>
-            <input class="form-control" id="dataRatio" type="text" placeholder="16/9" name="ratio" value="${option.ratio!}" pattern="[0-9]+[/][0-9]+" title="Number/Number" required>
-            <span class="input-group-addon">w/h</span>
-          </div>
-          <div class="input-group">
-            <label class="input-group-addon" for="dataFieldName">#i18n{uploadimage.option.FieldName}</label>
-            <input class="form-control" id="dataFieldName" type="text" placeholder="fieldName" name="fieldName" value="${option.fieldName!}" pattern="[a-zA-Z0-9]+" title="Alpha-Numeric" required>
-            <span class="input-group-addon">string</span>
-          </div>
-          	 <div class="container">
-				<input class="btn btn-primary" value="#i18n{uploadimage.button.submit}" type="submit"/>
-				<a class="btn btn-primary" href="javascript:history.go(-1)">#i18n{uploadimage.button.retour}</a>
-  			</div>
+            <div class="input-group">
+                <label class="input-group-addon" for="dataX">#i18n{uploadimage.option.X}</label>
+                <input class="form-control" id="dataX" type="number" placeholder="x" name="x" value="${option.x!}" required>
+                <span class="input-group-addon">px</span>
+            </div>
+            <div class="input-group">
+                <label class="input-group-addon" for="dataY">#i18n{uploadimage.option.Y}</label>
+                <input class="form-control" id="dataY" type="number" placeholder="y" name="y" value="${option.y!}" required>
+                <span class="input-group-addon">px</span>
+            </div>
+            <div class="input-group">
+                <label class="input-group-addon" for="dataWidth">#i18n{uploadimage.option.Width}</label>
+                <input class="form-control" id="dataWidth" type="number" placeholder="width" name="width" value="${option.width!}" required>
+                <span class="input-group-addon">px</span>
+            </div>
+            <div class="input-group">
+                <label class="input-group-addon" for="dataHeight">#i18n{uploadimage.option.Height}</label>
+                <input class="form-control" id="dataHeight" type="number" placeholder="height" name="height" value="${option.height!}" required>
+                <span class="input-group-addon">px</span>
+            </div>
+            <div class="input-group">
+                <label class="input-group-addon" for="dataRatio">#i18n{uploadimage.option.Ratio}</label>
+                <input class="form-control" id="dataRatio" type="text" placeholder="16/9" name="ratio" value="${option.ratio!}" pattern="[0-9]+[/][0-9]+" title="Number/Number" required>
+                <span class="input-group-addon">w/h</span>
+            </div>
+            <div class="input-group">
+                <label class="input-group-addon" for="dataMaxHeight">#i18n{uploadimage.option.maxHeight}</label>
+                <input class="form-control" id="dataMaxHeight" type="number" placeholder="maxHeight" name="maxHeight" value="${option.maxHeight!}" required>
+                <span class="input-group-addon">px</span>
+            </div>
+            <div class="input-group">
+                <label class="input-group-addon" for="dataFieldName">#i18n{uploadimage.option.FieldName}</label>
+                <input class="form-control" id="dataFieldName" type="text" placeholder="fieldName" name="fieldName" value="${option.fieldName!}" pattern="[a-zA-Z0-9]+" title="Alpha-Numeric" required>
+                <span class="input-group-addon">string</span>
+            </div>
+            <br>
+            <div class="container">
+                <input class="btn btn-primary" value="#i18n{uploadimage.button.submit}" type="submit"/>
+                <a class="btn btn-primary" href="javascript:history.go(-1)">#i18n{uploadimage.button.retour}</a>
+            </div>
         </div>
 
-  </form>
-  </div>
-  </#macro>
+    </form>
+</div>
+</#macro>

--- a/webapp/WEB-INF/templates/admin/plugins/uploadimage/manageuploadimage_tabs.html
+++ b/webapp/WEB-INF/templates/admin/plugins/uploadimage/manageuploadimage_tabs.html
@@ -1,62 +1,62 @@
-<form method="post"  action="jsp/admin/plugins/uploadimage/GetViewOptions.jsp?action=add">
-		<input class="btn btn-primary pull-right" type="submit" value="Creer une option">
+<form method="post" action="jsp/admin/plugins/uploadimage/GetViewOptions.jsp?action=add">
+    <input class="btn btn-primary pull-right" type="submit" value="Creer une option">
 </form>
 <@messages errors=errors /> <@messages infos=infos />
 <div class="box-body table-responsive">
-				<div>
-			
-				</div>				
-				<form method="post"  action="jsp/admin/plugins/uploadimage/ManageUploadimage.jsp">
-					<@paginationAdmin paginator=paginator form=0 combo=1  />
-				</form>
-				<table class="table table-hover">
-					<tr>
-						<th>
-						#i18n{uploadimage.option.FieldName}
-						</th>
-						<th>
-						Ratio
-						</th>
-						<th>
-						#i18n{uploadimage.option.Height}
-						</th>
-						<th>
-						 #i18n{uploadimage.option.Width}
-						</th>
-						<th>
-						 #i18n{uploadimage.option.Action}
-						</th>
-					</tr>
-					<#list list_options as option>
-						<tr>
-							<td>
-								${option.fieldName!}
-							</td>
-							<td>
-								${option.ratio!}
-							</td>
-							<td>
-								${option.height!}
-							</td>
-							<td>
-								${option.width!}
-							</td>
-							<td>
-								<a class="btn btn-primary btn-xs btn-flat" href="jsp/admin/plugins/uploadimage/GetViewOptions.jsp?id_option=${option.id}&action=modify_option" title="#i18n{portal.util.labelModify}">
-									<i class="fa fa-pencil"></i>
-								</a>
-								<a class="btn btn-primary btn-xs btn-flat" title="#i18n{announce.manage_categories.formPreview}" href="jsp/admin/plugins/uploadimage/GetViewOptions.jsp?id_option=${option.id}">
-									<i class="fa fa-eye"></i>
-								</a>
-								<a class="btn btn-danger btn-xs btn-flat" title="#i18n{announce.manage_categories.removeCategoryTitle}" href="jsp/admin/plugins/uploadimage/GetConfirmRemoveOptions.jsp?id_option=${option.id}">
-									<i class="fa fa-trash"></i>
-								</a>
-							</td>
-						</tr>
-					</#list>
-				</table>
-				<form method="post"  action="jsp/admin/plugins/uploadimage/ManageUploadimage.jsp">
-					<@paginationAdmin paginator=paginator form=0 combo=1  />
-				</form>
+    <div>
+
+    </div>
+    <form method="post" action="jsp/admin/plugins/uploadimage/ManageUploadimage.jsp">
+    <@paginationAdmin paginator=paginator form=0 combo=1  />
+    </form>
+    <table class="table table-hover">
+        <tr>
+            <th>
+                #i18n{uploadimage.option.FieldName}
+            </th>
+            <th>
+                Ratio
+            </th>
+            <th>
+                #i18n{uploadimage.option.Height}
+            </th>
+            <th>
+                #i18n{uploadimage.option.Width}
+            </th>
+            <th>
+                #i18n{uploadimage.option.Action}
+            </th>
+        </tr>
+    <#list list_options as option>
+        <tr>
+            <td>
+            ${option.fieldName!}
+            </td>
+            <td>
+            ${option.ratio!}
+            </td>
+            <td>
+            ${option.height!}
+            </td>
+            <td>
+            ${option.width!}
+            </td>
+            <td>
+                <a class="btn btn-primary btn-xs btn-flat" href="jsp/admin/plugins/uploadimage/GetViewOptions.jsp?id_option=${option.id}&action=modify_option" title="#i18n{portal.util.labelModify}">
+                    <i class="fa fa-pencil"></i>
+                </a>
+                <a class="btn btn-primary btn-xs btn-flat" title="#i18n{announce.manage_categories.formPreview}" href="jsp/admin/plugins/uploadimage/GetViewOptions.jsp?id_option=${option.id}">
+                    <i class="fa fa-eye"></i>
+                </a>
+                <a class="btn btn-danger btn-xs btn-flat" title="#i18n{announce.manage_categories.removeCategoryTitle}"
+                   href="jsp/admin/plugins/uploadimage/GetConfirmRemoveOptions.jsp?id_option=${option.id}">
+                    <i class="fa fa-trash"></i>
+                </a>
+            </td>
+        </tr>
+    </#list>
+    </table>
+    <form method="post" action="jsp/admin/plugins/uploadimage/ManageUploadimage.jsp">
+    <@paginationAdmin paginator=paginator form=0 combo=1  />
+    </form>
 </div>
-	

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -109,7 +109,6 @@ $(function () {
       if (URL) {
 
           $inputImage.change(function () {
-
               $('#initUpload').hide();
               $('#buttonOption${fieldName}').show();
               $('#img_div').show();
@@ -224,15 +223,11 @@ function resetBox(fieldName) {
 }
 
 function getCroppedCanva(fieldName){
-
-    var src = $('.cropper-view-box').find("img").attr('src');
-    if(src.match("^blob")){
-        var $element= $('.img-container'+fieldName+' > img');
-        result = $element.cropper('getCroppedCanvas', paramaters${fieldName});
-        $('#imagesrc'+fieldName).val(result.toDataURL());
-        $('#canvasImage'+fieldName).html(result);
-        $('#deleteButton'+fieldName).show();
-    }
+    var $element= $('.img-container'+fieldName+' > img');
+    result = $element.cropper('getCroppedCanvas', paramaters${fieldName});
+    $('#imagesrc'+fieldName).val(result.toDataURL());
+    $('#canvasImage'+fieldName).html(result);
+    $('#deleteButton'+fieldName).show();
 }
 
 function deleteImage(fieldName) {

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -110,7 +110,7 @@ $(function () {
 
           $inputImage.change(function () {
 
-              $('#label${fieldName}').hide();
+              $('#initUpload').hide();
               $('#buttonOption${fieldName}').show();
               $('#img_div').show();
 
@@ -202,12 +202,15 @@ function resetBox(fieldName) {
 
 function getCroppedCanva(fieldName){
 
-	var $element= $('.img-container'+fieldName+' > img');
-
-	result = $element.cropper('getCroppedCanvas', paramaters${fieldName});
-	$('#imagesrc'+fieldName).val(result.toDataURL());
-	$('#canvasImage'+fieldName).html(result);
-	$('#deleteButton'+fieldName).show();
+    var src = $('.cropper-view-box').find("img").attr('src');
+    if(src.match("^blob")){
+        console.log('test');
+        var $element= $('.img-container'+fieldName+' > img');
+        result = $element.cropper('getCroppedCanvas', paramaters${fieldName});
+        $('#imagesrc'+fieldName).val(result.toDataURL());
+        $('#canvasImage'+fieldName).html(result);
+        $('#deleteButton'+fieldName).show();
+    }
 }
 
 function deleteImage(fieldName) {
@@ -216,17 +219,17 @@ function deleteImage(fieldName) {
     $('#deleteButton' + fieldName).hide();
 }
 
-function supprimerImage(fieldName) {
+function supprimerImage(fieldName, file) {
 
     $('#img_div').hide();
     $('#buttonOption' + fieldName).hide();
-    $('#label' + fieldName).show()
+    $('#deleteButton' + fieldName).hide();
+    $('#initUpload').show()
 
     // Reset des champs
+    $('#canvasImage' + fieldName).html('');
     $('.cropper-canvas').find("img").attr("src", '');
     $('.cropper-view-box').find("img").attr("src", '');
     $('#img_file').attr("src", '');
-    $('#canvasImage' + fieldName).html('');
-    $('#imagesrc' + fieldName).val();
 
 }

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -126,8 +126,27 @@ $(function () {
 
                   $('#typeImage').val(file.type);
 
+
                   if (/^image\/\w+$/.test(file.type)) {
                       blobURL = URL.createObjectURL(file);
+
+                      // resize contenaire photo
+                      var img = new Image;
+                      img.src = blobURL;
+                      img.onload = function () {
+                          console.log(img.height);
+                          $('#img_div').height(function (index, height) {
+                              if (img.height > ${option.maxHeight}) {
+                                  return (${option.maxHeight});
+                              } else if (img.height < 100) {
+                                  return (100);
+                              }
+                              else {
+                                  return (img.height);
+                              }
+                          });
+                      };
+
                       $image.one('built.cropper', function () {
                           URL.revokeObjectURL(blobURL); // Revoke when load complete
 
@@ -205,7 +224,6 @@ function getCroppedCanva(fieldName){
 
     var src = $('.cropper-view-box').find("img").attr('src');
     if(src.match("^blob")){
-        console.log('test');
         var $element= $('.img-container'+fieldName+' > img');
         result = $element.cropper('getCroppedCanvas', paramaters${fieldName});
         $('#imagesrc'+fieldName).val(result.toDataURL());

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -3,7 +3,7 @@ var paramaters${fieldName} = { width: ${option.width}, height: ${option.height} 
 $(function () {
 
   'use strict';
-  
+
   var console = window.console || { log: function () {} },
       $alert = $('.docs-alert'),
       $message = $alert.find('.message'),
@@ -23,7 +23,7 @@ $(function () {
 
   // Demo
   // -------------------------------------------------------------------------
-	
+
   (function () {
     var $image = $('.img-container${fieldName} > img'),
         $dataX = $('#dataX${fieldName}'),
@@ -38,7 +38,7 @@ $(function () {
              width: ${option.width},
              height: ${option.height}
            },
-	 
+
            strict: ${option.strict?c},
            responsive: ${option.responsive?c},
            checkImageOrigin: ${option.checkImageOrigin?c},
@@ -74,8 +74,8 @@ $(function () {
          //  dragend: null,
          //  zoomin: null,
          //  zoomout: null,
-	
-          aspectRatio: ${option.ratio},	  
+
+          aspectRatio: ${option.ratio},
           preview: '.img-preview',
           crop: function (data) {
             $dataX.val(Math.round(data.x));
@@ -88,28 +88,28 @@ $(function () {
 
     $image.on({
       'build.cropper': function (e) {
-        
+
       },
       'built.cropper': function (e) {
-        
+
       },
       'dragstart.cropper': function (e) {
-        
+
       },
       'dragmove.cropper': function (e) {
-       
+
       },
       'dragend.cropper': function (e) {
-       
+
       },
       'zoomin.cropper': function (e) {
-     
+
       },
       'zoomout.cropper': function (e) {
-  
+
       },
       'change.cropper': function (e) {
-     
+
       }
     }).cropper(options);
 
@@ -134,35 +134,35 @@ $(function () {
             try {
               data.option = JSON.parse($target.val());
             } catch (e) {
-              
+
             }
           }
         }
-         
+
 
         result = $image.cropper(data.method, data.option);
 
 	if(data.method === 'deleteImage'){
-	      var fieldName= data.option; 
+	      var fieldName= data.option;
 	      $('#imagesrc'+fieldName).val( );
 	      $('#canvasImage'+fieldName).html('');
 	      $('#deleteButton'+fieldName).hide();
-	     
+
 	}
-		
+
         if (data.method === 'getCroppedCanvas') {
-		
+
 		$('#imagesrc${fieldName}').val(result.toDataURL());
 		$('#canvasImage${fieldName}').html(result);
 		$('#deleteButton${fieldName}').show();
         }
-	
+
 
         if ($.isPlainObject(result) && $target) {
           try {
             $target.val(JSON.stringify(result));
           } catch (e) {
-          
+
           }
         }
 
@@ -199,7 +199,7 @@ $(function () {
 
      // zoom
      var $zoom = $("zoom_in${fieldName}");
-    
+
     // Import image
     var $inputImage = $('#inputImage${fieldName}'),
         URL = window.URL || window.webkitURL,
@@ -208,41 +208,42 @@ $(function () {
     if (URL) {
 
       $inputImage.change(function () {
-	
-	$('#label${fieldName}').hide();
-	$('#buttonOption${fieldName}').show();
-	
+
+        $('#label${fieldName}').hide();
+        $('#buttonOption${fieldName}').show();
+        $('#img_div').show();
+
         var files = this.files,
             file;
 
         if (!$image.data('cropper')) {
           return;
         }
-	
+
         if (files && files.length) {
           file = files[0];
-	 
+
 
           if (/^image\/\w+$/.test(file.type)) {
             blobURL = URL.createObjectURL(file);
             $image.one('built.cropper', function () {
               URL.revokeObjectURL(blobURL); // Revoke when load complete
-		
+
             }).cropper('reset').cropper('load', blobURL);
-	    
+
             $inputImage.val('');
           } else {
             showMessage('Please choose an image file.');
           }
-	   
+
         }
       });
-	
-	
+
+
     } else {
       $inputImage.parent().remove();
     }
-    
+
 
     // Options
     $('.docs-options :checkbox').on('change', function () {
@@ -273,13 +274,13 @@ $(function () {
   if(!options.movable){
 	$('#move').hide();
    };
- 
+
 
   }());
 
-  
- 
-   
+
+
+
 });
 
 function zoomIn(fieldName) {
@@ -322,21 +323,35 @@ function getCroppedCanva(fieldName){
 
 	result = $element.cropper('getCroppedCanvas', paramaters${fieldName});
 	$('#imagesrc'+fieldName).val(result.toDataURL());
-	$('#canvasImage'+fieldName).html(result);	
+	$('#canvasImage'+fieldName).html(result);
 	$('#deleteButton'+fieldName).show();
 };
 
-function  getCanvasWithParam(fieldName, param){
-	var $element= $('.img-container'+fieldName+' > img');
-	result = $element.cropper('getCroppedCanvas', param);
-	$('#imagesrc'+fieldName).val(result.toDataURL());
-	$('#canvasImage'+fieldName).html(result);
-	$('#deleteButton'+fieldName).show();	
+function getCanvasWithParam(fieldName, param) {
+    var $element = $('.img-container' + fieldName + ' > img');
+    result = $element.cropper('getCroppedCanvas', param);
+    $('#imagesrc' + fieldName).val(result.toDataURL());
+    $('#canvasImage' + fieldName).html(result);
+    $('#deleteButton' + fieldName).show();
 };
 
-function  deleteImage(fieldName){ 
-	      $('#imagesrc'+fieldName).val( );
-	      $('#canvasImage'+fieldName).html('');
-	      $('#deleteButton'+fieldName).hide();	
+function deleteImage(fieldName) {
+    $('#imagesrc' + fieldName).val();
+    $('#canvasImage' + fieldName).html('');
+    $('#deleteButton' + fieldName).hide();
 };
 
+function supprimerImage(fieldName) {
+
+    $('#img_div').hide();
+    $('#buttonOption' + fieldName).hide();
+    $('#label' + fieldName).show()
+
+    // Reset des champs
+    $('.cropper-canvas').find("img").attr("src", '');
+    $('.cropper-view-box').find("img").attr("src", '');
+    $('#img_file').attr("src", '');
+    $('#canvasImage' + fieldName).html('');
+    $('#imagesrc' + fieldName).val();
+
+};

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -239,16 +239,14 @@ function deleteImage(fieldName) {
 function supprimerImage(fieldName, file) {
 
     // Reset des champs
-    $('#canvasImage' + fieldName).html('');
+    $('#img_file').attr("src", '');
     $('.cropper-canvas').find("img").attr("src", '');
     $('.cropper-view-box').find("img").attr("src", '');
-    $('#img_file').attr("src", '');
+    $('#canvasImage' + fieldName).html('');
 
-    $('#img_div').hide();
     $('#buttonOption' + fieldName).hide();
     $('#deleteButton' + fieldName).hide();
+    $('#img_div').hide();
     $('#initUpload').show()
-
-
 
 }

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -223,7 +223,6 @@ $(function () {
         if (files && files.length) {
           file = files[0];
 
-          $('#typeImage').val(file.type);
 
           if (/^image\/\w+$/.test(file.type)) {
             blobURL = URL.createObjectURL(file);

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -4,25 +4,25 @@ $(function () {
 
   'use strict';
 
-  var console = window.console || { log: function () {} },
-      $alert = $('.docs-alert'),
-      $message = $alert.find('.message'),
-      showMessage = function (message, type) {
-        $message.text(message);
+    var console = window.console || {
+                log: function () {
+                }
+            },
+        $alert = $('.docs-alert'),
+        $message = $alert.find('.message'),
+        showMessage = function (message, type) {
+            $message.text(message);
 
-        if (type) {
-          $message.addClass(type);
-        }
+            if (type) {
+                $message.addClass(type);
+            }
 
-        $alert.fadeIn();
+            $alert.fadeIn();
 
-        setTimeout(function () {
-          $alert.fadeOut();
-        }, 3000);
-      };
-
-  // Demo
-  // -------------------------------------------------------------------------
+            setTimeout(function () {
+                $alert.fadeOut();
+            }, 3000);
+        };
 
   (function () {
     var $image = $('.img-container${fieldName} > img'),
@@ -59,21 +59,6 @@ $(function () {
            cropBoxMovable: ${option.cropBoxMovable?c},
            cropBoxResizable: ${option.cropBoxResizable?c},
            doubleClickToggle: ${option.doubleClickToggle?c},
-
-        //   minCanvasWidth: ${option.x},
-        //   minCanvasHeight: ${option.x},
-        //   minCropBoxWidth: ${option.x},
-        //   minCropBoxHeight: ${option.x},
-        //   minContainerWidth: ${option.x},
-        //   minContainerHeight: ${option.x},
-
-         //  build: null,
-         //  built: null,
-         //  dragstart: null,
-         //  dragmove: null,
-         //  dragend: null,
-         //  zoomin: null,
-         //  zoomout: null,
 
           aspectRatio: ${option.ratio},
           preview: '.img-preview',
@@ -113,176 +98,73 @@ $(function () {
       }
     }).cropper(options);
 
-
-    // Methods
-    $(document.body).on('click', '[data-method]', function () {
-      var data = $(this).data(),
-          $target,
-          result;
-
-      if (!$image.data('cropper')) {
-        return;
-      }
-
-      if (data.method) {
-        data = $.extend({}, data); // Clone a new one
-
-        if (typeof data.target !== 'undefined') {
-          $target = $(data.target);
-
-          if (typeof data.option === 'undefined') {
-            try {
-              data.option = JSON.parse($target.val());
-            } catch (e) {
-
-            }
-          }
-        }
-
-
-        result = $image.cropper(data.method, data.option);
-
-	if(data.method === 'deleteImage'){
-	      var fieldName= data.option;
-	      $('#imagesrc'+fieldName).val( );
-	      $('#canvasImage'+fieldName).html('');
-	      $('#deleteButton'+fieldName).hide();
-
-	}
-
-        if (data.method === 'getCroppedCanvas') {
-
-		$('#imagesrc${fieldName}').val(result.toDataURL());
-		$('#canvasImage${fieldName}').html(result);
-		$('#deleteButton${fieldName}').show();
-        }
-
-
-        if ($.isPlainObject(result) && $target) {
-          try {
-            $target.val(JSON.stringify(result));
-          } catch (e) {
-
-          }
-        }
-
-      }
-    }).on('keydown', function (e) {
-
-      if (!$image.data('cropper')) {
-        return;
-      }
-
-      switch (e.which) {
-        case 37:
-          e.preventDefault();
-          $image.cropper('move', -1, 0);
-          break;
-
-        case 38:
-          e.preventDefault();
-          $image.cropper('move', 0, -1);
-          break;
-
-        case 39:
-          e.preventDefault();
-          $image.cropper('move', 1, 0);
-          break;
-
-        case 40:
-          e.preventDefault();
-          $image.cropper('move', 0, 1);
-          break;
-      }
-
-    });
-
-     // zoom
-     var $zoom = $("zoom_in${fieldName}");
+    // zoom
+    var $zoom = $("zoom_in${fieldName}");
 
     // Import image
     var $inputImage = $('#inputImage${fieldName}'),
         URL = window.URL || window.webkitURL,
         blobURL;
 
-    if (URL) {
+      if (URL) {
 
-      $inputImage.change(function () {
+          $inputImage.change(function () {
 
-        $('#label${fieldName}').hide();
-        $('#buttonOption${fieldName}').show();
-        $('#img_div').show();
+              $('#label${fieldName}').hide();
+              $('#buttonOption${fieldName}').show();
+              $('#img_div').show();
 
-        var files = this.files,
-            file;
+              var files = this.files,
+                  file;
 
-        if (!$image.data('cropper')) {
-          return;
-        }
+              if (!$image.data('cropper')) {
+                  return;
+              }
 
-        if (files && files.length) {
-          file = files[0];
+              if (files && files.length) {
+                  file = files[0];
 
-          $('#typeImage').val(file.type);
+                  $('#typeImage').val(file.type);
 
-          if (/^image\/\w+$/.test(file.type)) {
-            blobURL = URL.createObjectURL(file);
-            $image.one('built.cropper', function () {
-              URL.revokeObjectURL(blobURL); // Revoke when load complete
+                  if (/^image\/\w+$/.test(file.type)) {
+                      blobURL = URL.createObjectURL(file);
+                      $image.one('built.cropper', function () {
+                          URL.revokeObjectURL(blobURL); // Revoke when load complete
 
-            }).cropper('reset').cropper('load', blobURL);
+                      }).cropper('reset').cropper('load', blobURL);
 
-            $inputImage.val('');
-          } else {
-            showMessage('Please choose an image file.');
-          }
+                      $inputImage.val('');
+                  } else {
+                      showMessage('Please choose an image file.');
+                  }
 
-        }
-      });
+              }
+          });
 
-
-    } else {
-      $inputImage.parent().remove();
-    }
-
-
-    // Options
-    $('.docs-options :checkbox').on('change', function () {
-      var $this = $(this);
-
-      if (!$image.data('cropper')) {
-        return;
+      } else {
+          $inputImage.parent().remove();
       }
 
-      options[$this.val()] = $this.prop('checked');
-      $image.cropper('destroy').cropper(options);
-    });
+      //hide button
+      if (!options.rotatable) {
+          $('#rotate_right').hide();
+          $('#rotate_left').hide();
+      }
 
+      if (!options.zoomable) {
+          $('#zoom_in').hide();
+          $('#zoom_out').hide();
+      }
 
-    // Tooltips
-    $('[data-toggle="tooltip"]').tooltip();
-
-   //hide button
-
-  if(!options.rotatable){
-	$('#rotate_right').hide();
-	$('#rotate_left').hide();
-   };
-  if(!options.zoomable){
-	$('#zoom_in').hide();
-	$('#zoom_out').hide();
-   };
-  if(!options.movable){
-	$('#move').hide();
-   };
-
+      if (!options.movable) {
+          $('#move').hide();
+      }
 
   }());
 
-
-
-
 });
+
+// Fonctions
 
 function zoomIn(fieldName) {
     var element = ".img-container" + fieldName;
@@ -326,21 +208,13 @@ function getCroppedCanva(fieldName){
 	$('#imagesrc'+fieldName).val(result.toDataURL());
 	$('#canvasImage'+fieldName).html(result);
 	$('#deleteButton'+fieldName).show();
-};
-
-function getCanvasWithParam(fieldName, param) {
-    var $element = $('.img-container' + fieldName + ' > img');
-    result = $element.cropper('getCroppedCanvas', param);
-    $('#imagesrc' + fieldName).val(result.toDataURL());
-    $('#canvasImage' + fieldName).html(result);
-    $('#deleteButton' + fieldName).show();
-};
+}
 
 function deleteImage(fieldName) {
     $('#imagesrc' + fieldName).val();
     $('#canvasImage' + fieldName).html('');
     $('#deleteButton' + fieldName).hide();
-};
+}
 
 function supprimerImage(fieldName) {
 
@@ -355,4 +229,4 @@ function supprimerImage(fieldName) {
     $('#canvasImage' + fieldName).html('');
     $('#imagesrc' + fieldName).val();
 
-};
+}

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -135,7 +135,7 @@ $(function () {
 
                       $inputImage.val('');
                   } else {
-                      showMessage('Please choose an image file.');
+                      showMessage('${errorMsg}');
                   }
 
               }

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -145,19 +145,20 @@ $(function () {
           $inputImage.parent().remove();
       }
 
-      //hide button
-      if (!options.rotatable) {
-          $('#rotate_right').hide();
-          $('#rotate_left').hide();
+      $('#content_upload_image').show();
+      //show buttons
+      if (options.rotatable) {
+          $('#rotate_right').show();
+          $('#rotate_left').show();
       }
 
-      if (!options.zoomable) {
-          $('#zoom_in').hide();
-          $('#zoom_out').hide();
+      if (options.zoomable) {
+          $('#zoom_in').show();
+          $('#zoom_out').show();
       }
 
-      if (!options.movable) {
-          $('#move').hide();
+      if (options.movable) {
+          $('#move').show();
       }
 
   }());

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -133,24 +133,27 @@ $(function () {
                       // resize contenaire photo
                       var img = new Image;
                       img.src = blobURL;
+
                       img.onload = function () {
-                          console.log(img.height);
+                          var divHeight;
                           $('#img_div').height(function (index, height) {
                               if (img.height > ${option.maxHeight}) {
-                                  return (${option.maxHeight});
+                                  divHeight = (${option.maxHeight});
                               } else if (img.height < 100) {
-                                  return (100);
+                                  divHeight = 100;
                               }
                               else {
-                                  return (img.height);
+                                  divHeight = img.height;
                               }
+
+                              $image.one('built.cropper', function () {
+                                  URL.revokeObjectURL(blobURL); // Revoke when load complete
+
+                              }).cropper('reset').cropper('load', blobURL);
+
+                              return divHeight;
                           });
                       };
-
-                      $image.one('built.cropper', function () {
-                          URL.revokeObjectURL(blobURL); // Revoke when load complete
-
-                      }).cropper('reset').cropper('load', blobURL);
 
                       $inputImage.val('');
                   } else {

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -223,6 +223,7 @@ $(function () {
         if (files && files.length) {
           file = files[0];
 
+          $('#typeImage').val(file.type);
 
           if (/^image\/\w+$/.test(file.type)) {
             blobURL = URL.createObjectURL(file);

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -157,6 +157,9 @@ $(function () {
                       };
 
                       $inputImage.val('');
+                      
+                      $("#imgChange").val("true");
+                      
                   } else {
                       showMessage('${errorMsg}');
                   }

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -238,15 +238,17 @@ function deleteImage(fieldName) {
 
 function supprimerImage(fieldName, file) {
 
-    $('#img_div').hide();
-    $('#buttonOption' + fieldName).hide();
-    $('#deleteButton' + fieldName).hide();
-    $('#initUpload').show()
-
     // Reset des champs
     $('#canvasImage' + fieldName).html('');
     $('.cropper-canvas').find("img").attr("src", '');
     $('.cropper-view-box').find("img").attr("src", '');
     $('#img_file').attr("src", '');
+
+    $('#img_div').hide();
+    $('#buttonOption' + fieldName).hide();
+    $('#deleteButton' + fieldName).hide();
+    $('#initUpload').show()
+
+
 
 }

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/main.js
@@ -1,4 +1,5 @@
 var paramaters${fieldName} = { width: ${option.width}, height: ${option.height} };
+var imgSupprimer = false;
 
 $(function () {
 
@@ -150,6 +151,7 @@ $(function () {
 
                               }).cropper('reset').cropper('load', blobURL);
 
+                              imgSupprimer = false;
                               return divHeight;
                           });
                       };
@@ -223,11 +225,15 @@ function resetBox(fieldName) {
 }
 
 function getCroppedCanva(fieldName){
-    var $element= $('.img-container'+fieldName+' > img');
-    result = $element.cropper('getCroppedCanvas', paramaters${fieldName});
-    $('#imagesrc'+fieldName).val(result.toDataURL());
-    $('#canvasImage'+fieldName).html(result);
-    $('#deleteButton'+fieldName).show();
+
+    if(!imgSupprimer){
+        var $element= $('.img-container'+fieldName+' > img');
+        result = $element.cropper('getCroppedCanvas', paramaters${fieldName});
+        console.log(result.toDataURL());
+        $('#imagesrc'+fieldName).val(result.toDataURL());
+        $('#canvasImage'+fieldName).html(result);
+        $('#deleteButton'+fieldName).show();
+    }
 }
 
 function deleteImage(fieldName) {
@@ -236,17 +242,16 @@ function deleteImage(fieldName) {
     $('#deleteButton' + fieldName).hide();
 }
 
-function supprimerImage(fieldName, file) {
+function supprimerImage(fieldName) {
+
+    imgSupprimer = true;
 
     // Reset des champs
-    $('#img_file').attr("src", '');
-    $('.cropper-canvas').find("img").attr("src", '');
-    $('.cropper-view-box').find("img").attr("src", '');
-    $('#canvasImage' + fieldName).html('');
+    $('#imagesrc' + fieldName).val('');
 
     $('#buttonOption' + fieldName).hide();
     $('#deleteButton' + fieldName).hide();
     $('#img_div').hide();
     $('#initUpload').show()
-
 }
+

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -20,6 +20,8 @@
 </#macro>
 
 <#macro cropimage fieldName file cssClass synchronous supprimer=false typeImage="image/*" cssBootsrap="col-xs-12 col-lg-12" tooltipAide="" >
+<#assign editMode = file != ''>
+
 
 <!-- Content -->
 <div id="content_upload_image" style="display: none" >
@@ -29,7 +31,7 @@
         <div class="${cssBootsrap}">
 
             <!-- Bouton upload -->
-            <div id="initUpload" class="col-xs-12 col-lg-12"  <#if file !="" > style="display: none" </#if> >
+            <div id="initUpload" class="col-xs-12 col-lg-12"  <#if editMode > style="display: none" </#if> >
                 <@boutonUpload 'label' fieldName typeImage tooltipAide />
             </div>
 
@@ -50,7 +52,7 @@
     <!-- Boutons -->
     <div id="row2" class="row">
         <div class="${cssBootsrap}">
-            <div id="buttonOption${fieldName}" class="docs-buttons " <#if file =="" > style="display: none" </#if> >
+            <div id="buttonOption${fieldName}" class="docs-buttons " <#if !editMode > style="display: none" </#if> >
                 <div id="buttonOption" class="btn-group">
 
                     <button id="zoom_in" class="btn btn-primary" onClick="zoomIn('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_in}"  style="display: none" >
@@ -96,7 +98,7 @@
 
                     <#if supprimer >
                         <!-- Bouton supprimer -->
-                        <button id="supprimer" class="btn btn-primary btn-supprimer" onclick="supprimerImage('${fieldName}','${file}');" type="button" title="#i18n{uploadimage.model.title.supprimer}" >
+                        <button id="supprimer" class="btn btn-primary btn-supprimer" onclick="supprimerImage('${fieldName}');" type="button" title="#i18n{uploadimage.model.title.supprimer}" >
                             <span class="docs-tooltip" data-toggle="tooltip" data-placement="top" title="#i18n{uploadimage.model.title.supprimer.tooltip}">
                                 #i18n{uploadimage.model.title.supprimer}
                             </span>
@@ -144,7 +146,7 @@
 <script type="text/javascript">
     $(function () {
         'use strict';
-        if ('${synchronous}' === "true" && "${file}" != "") {
+        if ('${synchronous}' === "true" && editMode ) {
             $('#imagesrc${fieldName}').val("${file}");
             $('#canvasImage${fieldName}').html('<img id="img${fieldName}" width="320" height="180" src="${file}" />');
             $('#deleteButton${fieldName}').show();

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -45,6 +45,7 @@
             </div>
             <!-- Type de l'Image   -->
             <input type="hidden" id="typeImage" name="typeImage">
+            <input type="hidden" id="imgChange" name="imgChange" value="false" />
 
         </div>
     </div>

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -1,153 +1,124 @@
-
 <#macro addRequiredJsUploadImages>
-	<link rel="stylesheet" href="css/plugins/uploadimage/main.css" />
-	<link rel="stylesheet" href="css/plugins/uploadimage/cropper.css" />
-	<script type="text/javascript" src="js/plugins/uploadimage/cropper.js" ></script>
+<link rel="stylesheet" href="css/plugins/uploadimage/main.css"/>
+<link rel="stylesheet" href="css/plugins/uploadimage/cropper.css"/>
+<script type="text/javascript" src="js/plugins/uploadimage/cropper.js"></script>
 </#macro>
-<#macro cropimage  fieldName	file  cssClass synchronous >
+<#macro cropimage  fieldName    file  cssClass synchronous >
 
 
-  <!-- Content -->
-  <div id="content_upload_image"  class="">
-    <div id="row1"  class="row">
-      <div class="col-xs-8 col-md-16">
-        <!-- <h3 class="page-header">Demo:</h3> -->
-	 <label id="label${fieldName}" class="btn btn-primary btn-upload" for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}" <#if file !="" > style='display:none' </#if>>
-            <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept="image/*">
-            <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
-              <span class="icon icon-upload"></span> #i18n{uploadimage.model.upload.button} 
-            </span>
-	 </label>
-        <div id="img_div"  class="img-container${fieldName} ${cssClass!}">
-          <image id="img_file"  src="${file!}" alt="" class="">
-        </div>
-     </div>
-    <div id="row2" class="row">
-      <div id= "buttonOption${fieldName}" class="col-md-9 docs-buttons" <#if file =="" > style='display:none' </#if>>
-        <!-- <h3 class="page-header">Toolbar:</h3> -->	
-        <div id="buttonOption" class="btn-group" >
-	        
-         <!-- <button id="crop" class="btn btn-primary" data-method="setDragMode" data-option="crop" type="button" title="#i18n{uploadimage.model.title.crop}">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;setDragMode&quot;, &quot;crop&quot;)">
-              <span class="icon icon-crop"></span>
-            </span>
-          </button> -->
-		<!-- <button id="move" class="btn btn-primary" data-method="setDragMode" onClick="move('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.move}">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;setDragMode&quot;, &quot;move&quot;)">
-              <span class="icon icon-move"></span>
-            </span>
-        </button> -->
-          <button  id="zoom_in" class="btn btn-primary" onClick="zoomIn('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_in}">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;zoom&quot;, 0.1)">
-              <span class="icon icon-zoom-in"></span>
-            </span>
-          </button>
-          <button id="zoom_out" class="btn btn-primary" onClick="zoomOut('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_out}">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;zoom&quot;, -0.1)">
-              <span class="icon icon-zoom-out"></span>
-            </span>
-          </button>
-          <button id="rotate_left" class="btn btn-primary" onClick="rotate('${fieldName}', -45)" type="button" title="#i18n{uploadimage.model.title.rotate_left}">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;rotate&quot;, -45)">
-              <span class="icon icon-rotate-left"></span>
-            </span>
-          </button>
-          <button id="rotate_right" class="btn btn-primary" onClick="rotate('${fieldName}', 45)" type="button" title="#i18n{uploadimage.model.title.rotate_right}">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;rotate&quot;, 45)">
-              <span class="icon icon-rotate-right"></span>
-            </span>
-          </button>
+<!-- Content -->
+<div id="content_upload_image" class="">
+    <div id="row1" class="row">
+        <div class="col-xs-8 col-md-16">
+
+            <!-- Bouton upload -->
+            <label id="label${fieldName}" class="btn btn-primary btn-upload" for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}" <#if file !="" > style='display:none' </#if>>
+                <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept="image/*">
+                <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
+                    <span class="icon icon-upload"></span>
+                    #i18n{uploadimage.model.upload.button}
+                </span>
+            </label>
+
+            <!-- Image affichée  -->
+            <div id="img_div" class="img-container${fieldName} ${cssClass!}">
+                <image id="img_file" src="${file!}" alt="" class="">
+            </div>
 
         </div>
-	
-        <div id="buttons" class="btn-group">
 
-          <button id="crop" class="btn btn-primary" onClick="cropBox('${fieldName}')"  type="button" title="#i18n{uploadimage.model.title.crop}">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;crop&quot;)">
-              <span class="icon icon-crop"></span>
-            </span>
-          </button>
-          <button id="clear" class="btn btn-primary" onClick="clearBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.clear}">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;clear&quot;)">
-              <span class="icon icon-remove"></span>
-            </span>
-          </button>   
-          <button id="reset" class="btn btn-primary" onClick="resetBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.reset}">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;reset&quot;)">
-              <span class="icon icon-refresh"></span>
-            </span>
-          </button>
-          <label id="upload"  class="btn btn-primary" for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}">
-            <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept="image/*">
-            <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
-              <span class="icon icon-upload"></span> #i18n{uploadimage.model.upload.button}
-            </span>
-          </label>
-         
+        <div id="row2" class="row">
+            <div id="buttonOption${fieldName}" class="col-md-9 docs-buttons" <#if file =="" > style='display:none' </#if>>
+                <div id="buttonOption" class="btn-group">
+
+                    <button id="zoom_in" class="btn btn-primary" onClick="zoomIn('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_in}">
+                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;zoom&quot;, 0.1)">
+                          <span class="icon icon-zoom-in"></span>
+                        </span>
+                    </button>
+                    <button id="zoom_out" class="btn btn-primary" onClick="zoomOut('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_out}">
+                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;zoom&quot;, -0.1)">
+                          <span class="icon icon-zoom-out"></span>
+                        </span>
+                    </button>
+                    <button id="rotate_left" class="btn btn-primary" onClick="rotate('${fieldName}', -45)" type="button" title="#i18n{uploadimage.model.title.rotate_left}">
+                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;rotate&quot;, -45)">
+                          <span class="icon icon-rotate-left"></span>
+                        </span>
+                    </button>
+                    <button id="rotate_right" class="btn btn-primary" onClick="rotate('${fieldName}', 45)" type="button" title="#i18n{uploadimage.model.title.rotate_right}">
+                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;rotate&quot;, 45)">
+                          <span class="icon icon-rotate-right"></span>
+                        </span>
+                    </button>
+
+                </div>
+
+                <div id="buttons" class="btn-group">
+
+                    <button id="crop" class="btn btn-primary" onClick="cropBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.crop}">
+                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;crop&quot;)">
+                          <span class="icon icon-crop"></span>
+                        </span>
+                    </button>
+                    <button id="clear" class="btn btn-primary" onClick="clearBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.clear}">
+                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;clear&quot;)">
+                          <span class="icon icon-remove"></span>
+                        </span>
+                    </button>
+                    <button id="reset" class="btn btn-primary" onClick="resetBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.reset}">
+                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;reset&quot;)">
+                          <span class="icon icon-refresh"></span>
+                        </span>
+                    </button>
+                    <!-- Bouton upload -->
+                    <label id="upload" class="btn btn-primary" for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}">
+                        <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept="image/*">
+                        <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
+                          <span class="icon icon-upload"></span> #i18n{uploadimage.model.upload.button}
+                        </span>
+                    </label>
+
+                </div>
+
+                <div id="crp_canvas" class="btn-group">
+                    <button id="crp_button_canvas" class="btn btn-primary" onClick="getCroppedCanva('${fieldName}')" type="button">
+                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper${fieldName}(&quot;getCroppedCanvas&quot;)">
+                          #i18n{uploadimage.model.get.cropped.canvas}
+                        </span>
+                    </button>
+                </div>
+
+                <!-- Preview crop -->
+                <div id="row3" class="row">
+                    <input id="imagesrc${fieldName}" name="${fieldName}" type="hidden" value=""/>
+                    <button id="deleteButton${fieldName}" class="btn btn-default" onClick="deleteImage('${fieldName}')" type="button" title="#i18n{uploadimage.model.delete.button}"
+                            style="display:none">
+                        <span class="glyphicon glyphicon-remove-circle"></span> #i18n{uploadimage.model.delete.button}
+                    </button>
+                    <div style="max-width: 5px;" id="canvasImage${fieldName}"></div>
+                </div>
+            </div>
         </div>
-	<!--<div class="btn-group">
-
-	 <button id="destroy" class="btn btn-primary" data-method="destroy" type="button" title="Destroy" style="visibility:hidden;">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;destroy&quot;)">
-              <span class="icon icon-off"></span>
-            </span>
-          </button>
-	   <button id="disabled" class="btn btn-primary" data-method="disable" type="button" title="Disable" style="visibility:hidden;">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;disable&quot;)">
-              <span class="icon icon-lock"></span>
-            </span>
-          </button>
-          <button id="enable"  class="btn btn-primary" data-method="enable" type="button" title="Enable" style="visibility:hidden;">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;enable&quot;)">
-              <span class="icon icon-unlock"></span>
-            </span>
-          </button>
-	</div> -->
-
-        <div id="crp_canvas" class="btn-group">
-          <button  id="crp_button_canvas" class="btn btn-primary" onClick="getCroppedCanva('${fieldName}')" type="button">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper${fieldName}(&quot;getCroppedCanvas&quot;)">
-              #i18n{uploadimage.model.get.cropped.canvas}
-            </span>
-          </button>
-          <!-- <button id="id_crop_canvas" class="btn btn-primary" onClick="getCanvasWithParam('${fieldName}',{ width: 160, height: 90 } )"  type="button">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;getCroppedCanvas&quot;, { width: 160, height: 90 })">
-              160&times;90
-            </span>
-          </button>
-          <button class="btn btn-primary"  onClick="getCanvasWithParam('${fieldName}',{ width: 320, height: 180 } )" type="button">
-            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;getCroppedCanvas&quot;, { width: 320, height: 180 })">
-              320&times;180
-            </span>
-          </button> -->
-        </div>
-	<div id="row3" class="row">
-		<input id="imagesrc${fieldName}" name="${fieldName}" type="hidden" value="" />	
-		<button id="deleteButton${fieldName}" class="btn btn-default" onClick="deleteImage('${fieldName}')" type="button" title="#i18n{uploadimage.model.delete.button}" style="display:none">
-		      <span class="glyphicon glyphicon-remove-circle"></span> #i18n{uploadimage.model.delete.button}
-		</button>
-		<div style="max-width: 5px;" id="canvasImage${fieldName}"></div>
-	</div>	
-      </div><!-- /.docs-toggles -->
     </div>
-  </div>
 </div>
- <!-- Alert -->
+<!-- Alert -->
 <div class="docs-alert"><span class="warning message"></span></div>
 
-  <!-- Scripts -->
-<script type="text/javascript" src="jsp/site/plugins/uploadimage/GetMainUploadJs.jsp?fieldName=${fieldName}" ></script>
+<!-- Scripts -->
+<script type="text/javascript" src="jsp/site/plugins/uploadimage/GetMainUploadJs.jsp?fieldName=${fieldName}"></script>
 
 
 <script type="text/javascript">
-$(function () {
- 	'use strict';
-	if('${synchronous}'==="true" && "${file}" != ""){
-		$('#imagesrc${fieldName}').val("${file}");
-		$('#canvasImage${fieldName}').html('<img id="img${fieldName}" width="320" height="180" src="${file}" />');
-		$('#deleteButton${fieldName}').show();
-	};
-});
+    $(function () {
+        'use strict';
+        if ('${synchronous}' === "true" && "${file}" != "") {
+            $('#imagesrc${fieldName}').val("${file}");
+            $('#canvasImage${fieldName}').html('<img id="img${fieldName}" width="320" height="180" src="${file}" />');
+            $('#deleteButton${fieldName}').show();
+        }
+        ;
+    });
 </script>
 
 </#macro>

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -6,7 +6,7 @@
 
 <#macro boutonUpload id fieldName typeImage tooltipAide >
 
-    <label id="${id}" class="btn btn-primary btn-upload " for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}">
+    <label id="${id}" class="btn btn-primary btn-upload " for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}" >
         <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept=${typeImage}>
             <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
                 <span class="icon icon-upload"></span>
@@ -22,7 +22,7 @@
 <#macro cropimage fieldName file cssClass synchronous supprimer=false typeImage="image/*" cssBootsrap="col-xs-12 col-lg-12" tooltipAide="" >
 
 <!-- Content -->
-<div id="content_upload_image">
+<div id="content_upload_image" style="display: none" >
 
     <!-- Image ou bouton upload -->
     <div id="row1" class="row">
@@ -49,24 +49,24 @@
             <div id="buttonOption${fieldName}" class="docs-buttons " <#if file =="" > style="display: none" </#if> >
                 <div id="buttonOption" class="btn-group">
 
-                    <button id="zoom_in" class="btn btn-primary" onClick="zoomIn('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_in}">
+                    <button id="zoom_in" class="btn btn-primary" onClick="zoomIn('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_in}"  style="display: none" >
                             <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;zoom&quot;, 0.1)">
-                              <span class="icon icon-zoom-in"></span>
+                              <span id="zoom_in_icon" class="icon icon-zoom-in"></span>
                             </span>
                     </button>
-                    <button id="zoom_out" class="btn btn-primary" onClick="zoomOut('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_out}">
+                    <button id="zoom_out" class="btn btn-primary" onClick="zoomOut('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_out}"  style="display: none">
                             <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;zoom&quot;, -0.1)">
-                              <span class="icon icon-zoom-out"></span>
+                              <span id="zoom_out_icon" class="icon icon-zoom-out"></span>
                             </span>
                     </button>
-                    <button id="rotate_left" class="btn btn-primary" onClick="rotate('${fieldName}', -45)" type="button" title="#i18n{uploadimage.model.title.rotate_left}">
+                    <button id="rotate_left" class="btn btn-primary" onClick="rotate('${fieldName}', -45)" type="button" title="#i18n{uploadimage.model.title.rotate_left}"  style="display: none" >
                             <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;rotate&quot;, -45)">
-                              <span class="icon icon-rotate-left"></span>
+                              <span id="rotate_left_icon" class="icon icon-rotate-left"></span>
                             </span>
                     </button>
-                    <button id="rotate_right" class="btn btn-primary" onClick="rotate('${fieldName}', 45)" type="button" title="#i18n{uploadimage.model.title.rotate_right}">
+                    <button id="rotate_right" class="btn btn-primary" onClick="rotate('${fieldName}', 45)" type="button" title="#i18n{uploadimage.model.title.rotate_right}"  style="display: none" >
                             <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;rotate&quot;, 45)">
-                              <span class="icon icon-rotate-right"></span>
+                              <span id="rotate_right_icon" class="icon icon-rotate-right"></span>
                             </span>
                     </button>
 
@@ -74,17 +74,17 @@
 
                 <div id="buttons" class="btn-group">
 
-                    <button id="crop" class="btn btn-primary" onClick="cropBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.crop}">
+                    <button id="crop" class="btn btn-primary" onClick="cropBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.crop}"  >
                             <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;crop&quot;)">
                               <span class="icon icon-crop"></span>
                             </span>
                     </button>
-                    <button id="clear" class="btn btn-primary" onClick="clearBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.clear}">
+                    <button id="clear" class="btn btn-primary" onClick="clearBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.clear}"  >
                             <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;clear&quot;)">
                               <span class="icon icon-remove"></span>
                             </span>
                     </button>
-                    <button id="reset" class="btn btn-primary" onClick="resetBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.reset}">
+                    <button id="reset" class="btn btn-primary" onClick="resetBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.reset}" >
                             <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;reset&quot;)">
                               <span class="icon icon-refresh"></span>
                             </span>
@@ -92,9 +92,8 @@
 
                     <#if supprimer >
                         <!-- Bouton supprimer -->
-                        <button id="supprimer" class="btn btn-primary btn-supprimer" onclick="supprimerImage('${fieldName}','${file}');" type="button" title="#i18n{uploadimage.model.title.supprimer}">
+                        <button id="supprimer" class="btn btn-primary btn-supprimer" onclick="supprimerImage('${fieldName}','${file}');" type="button" title="#i18n{uploadimage.model.title.supprimer}" >
                             <span class="docs-tooltip" data-toggle="tooltip" data-placement="top" title="#i18n{uploadimage.model.title.supprimer.tooltip}">
-                            <span class="icon icon-remove"></span>
                                 #i18n{uploadimage.model.title.supprimer}
                             </span>
                         </button>
@@ -105,8 +104,8 @@
 
                 </div>
 
-                <div id="crp_canvas" class="btn-group">
-                    <button id="crp_button_canvas" class="btn btn-primary" onClick="getCroppedCanva('${fieldName}')" type="button">
+                <div id="crp_canvas" class="btn-group" >
+                    <button id="crp_button_canvas" class="btn btn-primary" onClick="getCroppedCanva('${fieldName}')" type="button" >
                             <span class="docs-tooltip" data-toggle="tooltip" data-placement="top" title="$().cropper${fieldName}(&quot;getCroppedCanvas&quot;)">
                               #i18n{uploadimage.model.get.cropped.canvas}
                             </span>

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -29,13 +29,17 @@
         <div class="${cssBootsrap}">
 
             <!-- Bouton upload -->
-            <div id="initUpload"  <#if file !="" > style="display: none" </#if> >
+            <div id="initUpload" class="col-xs-12 col-lg-12"  <#if file !="" > style="display: none" </#if> >
                 <@boutonUpload 'label' fieldName typeImage tooltipAide />
             </div>
 
-            <!-- Image affichée  -->
-            <div id="img_div" class="img-container${fieldName} ${cssClass!}">
-                <image id="img_file" src="${file!}" alt="">
+            <div class="row">
+                <div class="${cssBootsrap!}">
+                    <!-- Image affichée  -->
+                    <div id="img_div" class="img-div img-container${fieldName}">
+                        <image id="img_file" src="${file!}" alt="">
+                    </div>
+                </div>
             </div>
             <!-- Type de l'Image   -->
             <input type="hidden" id="typeImage" name="typeImage">

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -3,16 +3,16 @@
 <link rel="stylesheet" href="css/plugins/uploadimage/cropper.css"/>
 <script type="text/javascript" src="js/plugins/uploadimage/cropper.js"></script>
 </#macro>
-<#macro cropimage  fieldName    file  cssClass synchronous >
+<#macro cropimage fieldName file cssClass synchronous supprimer=false >
 
 
 <!-- Content -->
-<div id="content_upload_image" class="">
+<div id="content_upload_image">
     <div id="row1" class="row">
         <div class="col-xs-8 col-md-16">
 
             <!-- Bouton upload -->
-            <label id="label${fieldName}" class="btn btn-primary btn-upload" for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}" <#if file !="" > style='display:none' </#if>>
+            <label id="label${fieldName}" class="btn btn-primary btn-upload " for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}" <#if file !="" > style="display: none" </#if> >
                 <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept="image/*">
                 <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
                     <span class="icon icon-upload"></span>
@@ -22,34 +22,34 @@
 
             <!-- Image affichée  -->
             <div id="img_div" class="img-container${fieldName} ${cssClass!}">
-                <image id="img_file" src="${file!}" alt="" class="">
+                <image id="img_file" src="${file!}" alt="">
             </div>
 
         </div>
 
         <div id="row2" class="row">
-            <div id="buttonOption${fieldName}" class="col-md-9 docs-buttons" <#if file =="" > style='display:none' </#if>>
+            <div id="buttonOption${fieldName}" class="col-md-9 docs-buttons " <#if file =="" > style="display: none" </#if> >
                 <div id="buttonOption" class="btn-group">
 
                     <button id="zoom_in" class="btn btn-primary" onClick="zoomIn('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_in}">
-                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;zoom&quot;, 0.1)">
-                          <span class="icon icon-zoom-in"></span>
-                        </span>
+                            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;zoom&quot;, 0.1)">
+                              <span class="icon icon-zoom-in"></span>
+                            </span>
                     </button>
                     <button id="zoom_out" class="btn btn-primary" onClick="zoomOut('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_out}">
-                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;zoom&quot;, -0.1)">
-                          <span class="icon icon-zoom-out"></span>
-                        </span>
+                            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;zoom&quot;, -0.1)">
+                              <span class="icon icon-zoom-out"></span>
+                            </span>
                     </button>
                     <button id="rotate_left" class="btn btn-primary" onClick="rotate('${fieldName}', -45)" type="button" title="#i18n{uploadimage.model.title.rotate_left}">
-                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;rotate&quot;, -45)">
-                          <span class="icon icon-rotate-left"></span>
-                        </span>
+                            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;rotate&quot;, -45)">
+                              <span class="icon icon-rotate-left"></span>
+                            </span>
                     </button>
                     <button id="rotate_right" class="btn btn-primary" onClick="rotate('${fieldName}', 45)" type="button" title="#i18n{uploadimage.model.title.rotate_right}">
-                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;rotate&quot;, 45)">
-                          <span class="icon icon-rotate-right"></span>
-                        </span>
+                            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;rotate&quot;, 45)">
+                              <span class="icon icon-rotate-right"></span>
+                            </span>
                     </button>
 
                 </div>
@@ -57,35 +57,47 @@
                 <div id="buttons" class="btn-group">
 
                     <button id="crop" class="btn btn-primary" onClick="cropBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.crop}">
-                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;crop&quot;)">
-                          <span class="icon icon-crop"></span>
-                        </span>
+                            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;crop&quot;)">
+                              <span class="icon icon-crop"></span>
+                            </span>
                     </button>
                     <button id="clear" class="btn btn-primary" onClick="clearBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.clear}">
-                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;clear&quot;)">
-                          <span class="icon icon-remove"></span>
-                        </span>
+                            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;clear&quot;)">
+                              <span class="icon icon-remove"></span>
+                            </span>
                     </button>
                     <button id="reset" class="btn btn-primary" onClick="resetBox('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.reset}">
-                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;reset&quot;)">
-                          <span class="icon icon-refresh"></span>
-                        </span>
+                            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;reset&quot;)">
+                              <span class="icon icon-refresh"></span>
+                            </span>
                     </button>
+
+                    <#if supprimer >
+                        <!-- Bouton supprimer -->
+                        <button id="supprimer" class="btn btn-primary btn-supprimer" onclick="supprimerImage('${fieldName}');" type="button" title="#i18n{uploadimage.model.title.supprimer}">
+                            <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.supprimer.tooltip}">
+                            <span class="icon icon-remove"></span>
+                                #i18n{uploadimage.model.title.supprimer}
+                            </span>
+                        </button>
+                    </#if>
+
                     <!-- Bouton upload -->
-                    <label id="upload" class="btn btn-primary" for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}">
+                    <label id="upload" class="btn btn-primary btn-upload" for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}">
                         <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept="image/*">
-                        <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
-                          <span class="icon icon-upload"></span> #i18n{uploadimage.model.upload.button}
-                        </span>
+                            <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
+                              <span class="icon icon-upload"></span>
+                                #i18n{uploadimage.model.upload.button}
+                            </span>
                     </label>
 
                 </div>
 
                 <div id="crp_canvas" class="btn-group">
                     <button id="crp_button_canvas" class="btn btn-primary" onClick="getCroppedCanva('${fieldName}')" type="button">
-                        <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper${fieldName}(&quot;getCroppedCanvas&quot;)">
-                          #i18n{uploadimage.model.get.cropped.canvas}
-                        </span>
+                            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper${fieldName}(&quot;getCroppedCanvas&quot;)">
+                              #i18n{uploadimage.model.get.cropped.canvas}
+                            </span>
                     </button>
                 </div>
 
@@ -94,7 +106,8 @@
                     <input id="imagesrc${fieldName}" name="${fieldName}" type="hidden" value=""/>
                     <button id="deleteButton${fieldName}" class="btn btn-default" onClick="deleteImage('${fieldName}')" type="button" title="#i18n{uploadimage.model.delete.button}"
                             style="display:none">
-                        <span class="glyphicon glyphicon-remove-circle"></span> #i18n{uploadimage.model.delete.button}
+                        <span class="glyphicon glyphicon-remove-circle"></span>
+                        #i18n{uploadimage.model.delete.button}
                     </button>
                     <div style="max-width: 5px;" id="canvasImage${fieldName}"></div>
                 </div>
@@ -102,6 +115,7 @@
         </div>
     </div>
 </div>
+
 <!-- Alert -->
 <div class="docs-alert"><span class="warning message"></span></div>
 

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -46,7 +46,7 @@
 
         </div>
     </div>
-
+    <br>
     <!-- Boutons -->
     <div id="row2" class="row">
         <div class="${cssBootsrap}">

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -3,7 +3,7 @@
 <link rel="stylesheet" href="css/plugins/uploadimage/cropper.css"/>
 <script type="text/javascript" src="js/plugins/uploadimage/cropper.js"></script>
 </#macro>
-<#macro cropimage fieldName file cssClass synchronous supprimer=false >
+<#macro cropimage fieldName file cssClass synchronous supprimer=false typeImage="image/*" >
 
 
 <!-- Content -->
@@ -13,7 +13,7 @@
 
             <!-- Bouton upload -->
             <label id="label${fieldName}" class="btn btn-primary btn-upload " for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}" <#if file !="" > style="display: none" </#if> >
-                <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept="image/*">
+                <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept=${typeImage}>
                 <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
                     <span class="icon icon-upload"></span>
                     #i18n{uploadimage.model.upload.button}
@@ -86,7 +86,7 @@
 
                     <!-- Bouton upload -->
                     <label id="upload" class="btn btn-primary btn-upload" for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}">
-                        <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept="image/*">
+                        <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept=${typeImage}>
                             <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
                               <span class="icon icon-upload"></span>
                                 #i18n{uploadimage.model.upload.button}

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -3,13 +3,15 @@
 <link rel="stylesheet" href="css/plugins/uploadimage/cropper.css"/>
 <script type="text/javascript" src="js/plugins/uploadimage/cropper.js"></script>
 </#macro>
-<#macro cropimage fieldName file cssClass synchronous supprimer=false typeImage="image/*" >
+<#macro cropimage fieldName file cssClass synchronous supprimer=false typeImage="image/*" cssBootsrap="col-xs-12 col-lg-12" >
 
 
 <!-- Content -->
 <div id="content_upload_image">
+
+    <!-- image ou bouton upload -->
     <div id="row1" class="row">
-        <div class="col-xs-8 col-md-16">
+        <div class="${cssBootsrap}">
 
             <!-- Bouton upload -->
             <label id="label${fieldName}" class="btn btn-primary btn-upload " for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}" <#if file !="" > style="display: none" </#if> >
@@ -28,9 +30,12 @@
             <input type="hidden" id="typeImage" name="typeImage">
 
         </div>
+    </div>
 
-        <div id="row2" class="row">
-            <div id="buttonOption${fieldName}" class="col-md-9 docs-buttons " <#if file =="" > style="display: none" </#if> >
+    <!-- Boutons -->
+    <div id="row2" class="row">
+        <div class="${cssBootsrap}">
+            <div id="buttonOption${fieldName}" class="docs-buttons " <#if file =="" > style="display: none" </#if> >
                 <div id="buttonOption" class="btn-group">
 
                     <button id="zoom_in" class="btn btn-primary" onClick="zoomIn('${fieldName}')" type="button" title="#i18n{uploadimage.model.title.zoom_in}">
@@ -102,20 +107,23 @@
                             </span>
                     </button>
                 </div>
-
-                <!-- Preview crop -->
-                <div id="row3" class="row">
-                    <input id="imagesrc${fieldName}" name="${fieldName}" type="hidden" value=""/>
-                    <button id="deleteButton${fieldName}" class="btn btn-default" onClick="deleteImage('${fieldName}')" type="button" title="#i18n{uploadimage.model.delete.button}"
-                            style="display:none">
-                        <span class="glyphicon glyphicon-remove-circle"></span>
-                        #i18n{uploadimage.model.delete.button}
-                    </button>
-                    <div style="max-width: 5px;" id="canvasImage${fieldName}"></div>
-                </div>
             </div>
         </div>
     </div>
+
+    <!-- Preview crop -->
+    <div id="row3" class="row">
+        <div class="col-xs-12 col-lg-12">
+            <input id="imagesrc${fieldName}" name="${fieldName}" type="hidden" value=""/>
+            <button id="deleteButton${fieldName}" class="btn btn-default" onClick="deleteImage('${fieldName}')" type="button" title="#i18n{uploadimage.model.delete.button}"
+                    style="display:none">
+                <span class="glyphicon glyphicon-remove-circle"></span>
+                #i18n{uploadimage.model.delete.button}
+            </button>
+            <div style="max-width: 5px;" id="canvasImage${fieldName}"></div>
+        </div>
+    </div>
+
 </div>
 
 <!-- Alert -->

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -3,7 +3,7 @@
 <link rel="stylesheet" href="css/plugins/uploadimage/cropper.css"/>
 <script type="text/javascript" src="js/plugins/uploadimage/cropper.js"></script>
 </#macro>
-<#macro cropimage fieldName file cssClass synchronous supprimer=false typeImage="image/*" cssBootsrap="col-xs-12 col-lg-12" >
+<#macro cropimage fieldName file cssClass synchronous supprimer=false typeImage="image/*" cssBootsrap="col-xs-12 col-lg-12" tooltipAide="" >
 
 
 <!-- Content -->
@@ -82,7 +82,7 @@
                     <#if supprimer >
                         <!-- Bouton supprimer -->
                         <button id="supprimer" class="btn btn-primary btn-supprimer" onclick="supprimerImage('${fieldName}');" type="button" title="#i18n{uploadimage.model.title.supprimer}">
-                            <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.supprimer.tooltip}">
+                            <span class="docs-tooltip" data-toggle="tooltip" data-placement="top" title="#i18n{uploadimage.model.title.supprimer.tooltip}">
                             <span class="icon icon-remove"></span>
                                 #i18n{uploadimage.model.title.supprimer}
                             </span>
@@ -92,17 +92,20 @@
                     <!-- Bouton upload -->
                     <label id="upload" class="btn btn-primary btn-upload" for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}">
                         <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept=${typeImage}>
-                            <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
+                            <span class="docs-tooltip" data-toggle="tooltip" data-placement="top" title="#i18n{uploadimage.model.title.upload.tooltip}">
                               <span class="icon icon-upload"></span>
                                 #i18n{uploadimage.model.upload.button}
                             </span>
                     </label>
+                    <#if tooltipAide != "">
+                        <span id="tooltip_photo" class="aide-photo hidden glyphicon glyphicon-question-sign" data-toggle="tooltip" data-original-title="">${tooltipAide}</span>
+                    </#if>
 
                 </div>
 
                 <div id="crp_canvas" class="btn-group">
                     <button id="crp_button_canvas" class="btn btn-primary" onClick="getCroppedCanva('${fieldName}')" type="button">
-                            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper${fieldName}(&quot;getCroppedCanvas&quot;)">
+                            <span class="docs-tooltip" data-toggle="tooltip" data-placement="top" title="$().cropper${fieldName}(&quot;getCroppedCanvas&quot;)">
                               #i18n{uploadimage.model.get.cropped.canvas}
                             </span>
                     </button>
@@ -140,9 +143,25 @@
             $('#imagesrc${fieldName}').val("${file}");
             $('#canvasImage${fieldName}').html('<img id="img${fieldName}" width="320" height="180" src="${file}" />');
             $('#deleteButton${fieldName}').show();
-        }
-        ;
+        };
+
+        $('[data-toggle="tooltip"]').tooltip(
+            {
+                html: true,
+                animation: true
+            }
+        );
+
+        $('.aide-photo').each(function (index, value) {
+            $(this).removeClass("hidden");
+            $(this).html().replace('"', '\"');
+            $(this).attr('data-original-title', $(this).html());
+            $(this).html("");
+        });
+
     });
+
+
 </script>
 
 </#macro>

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -24,8 +24,6 @@
             <div id="img_div" class="img-container${fieldName} ${cssClass!}">
                 <image id="img_file" src="${file!}" alt="">
             </div>
-            <!-- Type de l'Image   -->
-            <input type="hidden" id="typeImage" name="typeImage">
 
         </div>
 

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -24,6 +24,8 @@
             <div id="img_div" class="img-container${fieldName} ${cssClass!}">
                 <image id="img_file" src="${file!}" alt="">
             </div>
+            <!-- Type de l'Image   -->
+            <input type="hidden" id="typeImage" name="typeImage">
 
         </div>
 

--- a/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
+++ b/webapp/WEB-INF/templates/skin/plugins/uploadimage/uploadimage.html
@@ -3,24 +3,35 @@
 <link rel="stylesheet" href="css/plugins/uploadimage/cropper.css"/>
 <script type="text/javascript" src="js/plugins/uploadimage/cropper.js"></script>
 </#macro>
-<#macro cropimage fieldName file cssClass synchronous supprimer=false typeImage="image/*" cssBootsrap="col-xs-12 col-lg-12" tooltipAide="" >
 
+<#macro boutonUpload id fieldName typeImage tooltipAide >
+
+    <label id="${id}" class="btn btn-primary btn-upload " for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}">
+        <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept=${typeImage}>
+            <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
+                <span class="icon icon-upload"></span>
+                #i18n{uploadimage.model.upload.button}
+            </span>
+    </label>
+    <#if tooltipAide != "">
+    <span id="tooltip_photo" class="aide-photo hidden glyphicon glyphicon-question-sign" data-toggle="tooltip" data-original-title="">${tooltipAide}</span>
+    </#if>
+
+</#macro>
+
+<#macro cropimage fieldName file cssClass synchronous supprimer=false typeImage="image/*" cssBootsrap="col-xs-12 col-lg-12" tooltipAide="" >
 
 <!-- Content -->
 <div id="content_upload_image">
 
-    <!-- image ou bouton upload -->
+    <!-- Image ou bouton upload -->
     <div id="row1" class="row">
         <div class="${cssBootsrap}">
 
             <!-- Bouton upload -->
-            <label id="label${fieldName}" class="btn btn-primary btn-upload " for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}" <#if file !="" > style="display: none" </#if> >
-                <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept=${typeImage}>
-                <span class="docs-tooltip" data-toggle="tooltip" title="#i18n{uploadimage.model.title.upload.tooltip}">
-                    <span class="icon icon-upload"></span>
-                    #i18n{uploadimage.model.upload.button}
-                </span>
-            </label>
+            <div id="initUpload"  <#if file !="" > style="display: none" </#if> >
+                <@boutonUpload 'label' fieldName typeImage tooltipAide />
+            </div>
 
             <!-- Image affichée  -->
             <div id="img_div" class="img-container${fieldName} ${cssClass!}">
@@ -81,7 +92,7 @@
 
                     <#if supprimer >
                         <!-- Bouton supprimer -->
-                        <button id="supprimer" class="btn btn-primary btn-supprimer" onclick="supprimerImage('${fieldName}');" type="button" title="#i18n{uploadimage.model.title.supprimer}">
+                        <button id="supprimer" class="btn btn-primary btn-supprimer" onclick="supprimerImage('${fieldName}','${file}');" type="button" title="#i18n{uploadimage.model.title.supprimer}">
                             <span class="docs-tooltip" data-toggle="tooltip" data-placement="top" title="#i18n{uploadimage.model.title.supprimer.tooltip}">
                             <span class="icon icon-remove"></span>
                                 #i18n{uploadimage.model.title.supprimer}
@@ -90,16 +101,7 @@
                     </#if>
 
                     <!-- Bouton upload -->
-                    <label id="upload" class="btn btn-primary btn-upload" for="inputImage${fieldName}" title="#i18n{uploadimage.model.title.upload}">
-                        <input class="sr-only" id="inputImage${fieldName}" name="file" type="file" accept=${typeImage}>
-                            <span class="docs-tooltip" data-toggle="tooltip" data-placement="top" title="#i18n{uploadimage.model.title.upload.tooltip}">
-                              <span class="icon icon-upload"></span>
-                                #i18n{uploadimage.model.upload.button}
-                            </span>
-                    </label>
-                    <#if tooltipAide != "">
-                        <span id="tooltip_photo" class="aide-photo hidden glyphicon glyphicon-question-sign" data-toggle="tooltip" data-original-title="">${tooltipAide}</span>
-                    </#if>
+                    <@boutonUpload 'upload' fieldName typeImage tooltipAide />
 
                 </div>
 
@@ -161,7 +163,9 @@
 
     });
 
-
 </script>
 
 </#macro>
+
+
+

--- a/webapp/css/plugins/uploadimage/main.css
+++ b/webapp/css/plugins/uploadimage/main.css
@@ -76,7 +76,7 @@
 .docs-alert {
   display: none;
   position: fixed;
-  top: 20px;
+  top: 50px;
   left: 0;
   right: 0;
   height: 0;

--- a/webapp/css/plugins/uploadimage/main.css
+++ b/webapp/css/plugins/uploadimage/main.css
@@ -76,12 +76,13 @@
 .docs-alert {
   display: none;
   position: fixed;
-  top: 50px;
+  top: 30px;
   left: 0;
   right: 0;
   height: 0;
   text-align: center;
   opacity: 0.9;
+  z-index: 100;
 }
 
 .docs-alert .message {

--- a/webapp/css/plugins/uploadimage/main.css
+++ b/webapp/css/plugins/uploadimage/main.css
@@ -340,3 +340,8 @@ body {
 .aide-photo {
   padding-left: 5px;
 }
+
+.img-div {
+  margin: auto;
+  padding-block-end: 25px;
+}

--- a/webapp/css/plugins/uploadimage/main.css
+++ b/webapp/css/plugins/uploadimage/main.css
@@ -331,4 +331,12 @@ body {
   left: 0px; 
   top: 149.063px;
   
-}  
+}
+
+.hidden {
+  display: none;
+}
+
+.aide-photo {
+  padding-left: 5px;
+}


### PR DESCRIPTION
JIRA PUI-23 : Pas de boutton "Supprimer"
JIRA PUI-22 : Le type de l'image est toujours png
JIRA PUI-17 : Paramétrable du type de fichier accepté
JIRA PUI-26 : Gérer le mode sans JS
JIRA PUI-27 : Ajouter une icône d'aide avec un tooltip affichant un text
JIRA    PUI-28 : Ajuster dynamiquement la taille de la photo affichée à sa taille réelle
JIRA PUI-29 : Externaliser les messages d'erreurs 
JIRA PUI-30 : Mise en forme des élements du plugin 
